### PR TITLE
Use monotonic time

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 six>=1.7.0
 futures>=3.0;python_version=='2.7' or python_version=='2.6' # BSD
+monotonic>=0.6 # Apache-2.0

--- a/tenacity.py
+++ b/tenacity.py
@@ -15,11 +15,12 @@
 # limitations under the License.
 
 import random
-import six
 import sys
 import time
 
 from concurrent import futures
+from monotonic import monotonic as now
+import six
 
 # sys.maxint / 2, since Python 3.2 doesn't have a sys.maxint...
 try:
@@ -247,7 +248,7 @@ class Retrying(object):
         self._after_attempts = after_attempts
 
     def call(self, fn, *args, **kwargs):
-        start_time = int(round(time.time() * 1000))
+        start_time = int(round(now() * 1000))
         attempt_number = 1
         while True:
             if self._before_attempts:
@@ -270,7 +271,7 @@ class Retrying(object):
                 self._after_attempts(attempt_number)
 
             delay_since_first_attempt_ms = int(
-                round(time.time() * 1000)
+                round(now() * 1000)
             ) - start_time
             if self.stop(attempt_number, delay_since_first_attempt_ms):
                 six.raise_from(RetryError(fut), fut.exception())


### PR DESCRIPTION
Monotonic time has the nice benefit of never
going backwards or getting messed up by NTPd
so use it instead of time.time for computing
durations (its a built-in on py3.x so we might
as well).