### PR TITLE
Remove dead versions of py 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: python
 python:
   - 2.6
   - 2.7
-  - 3.2
-  - 3.3
   - 3.4
   - 3.5
   - pypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,6 @@ classifier =
     Programming Language :: Python
     Programming Language :: Python :: 2.6
     Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3.2
-    Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Topic :: Utilities


### PR DESCRIPTION
The less pytho versions we have to
try to think about supporting (and
dealing with there edge-cases) the
better.

Fixes issue #4