### PR TITLE
Add  wait_chain()

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -120,6 +120,17 @@ services and other remote endpoints.
         print "Wait at least 3 seconds, and add up to 2 seconds of random delay"
 
 
+Sometimes it's necessary to build a chain of backoffs.
+
+.. code-block:: python
+
+    @retry(wait=wait_chain(*[wait_fixed(3000) for i in range(3)] +
+                           [wait_fixed(7000) for i in range(2)] +
+                           [wait_fixed(9000)]))
+    def wait_fixed_chained():
+        print "Wait 3s for 3 attempts, 7s for the next 2 attempts and 9s for all attempts thereafter"
+
+
 We have a few options for dealing with retries that raise specific or general
 exceptions, as in the cases here.
 

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -35,6 +35,7 @@ from .stop import stop_after_delay  # noqa
 from .stop import stop_never  # noqa
 
 # Import all built-in wait strategies for easier usage.
+from .wait import wait_chain  # noqa
 from .wait import wait_combine  # noqa
 from .wait import wait_exponential  # noqa
 from .wait import wait_fixed  # noqa

--- a/tenacity/tests/test_tenacity.py
+++ b/tenacity/tests/test_tenacity.py
@@ -153,6 +153,25 @@ class TestWaitConditions(unittest.TestCase):
             self.assertLess(w, 8)
             self.assertGreaterEqual(w, 5)
 
+    def _assert_range(self, wait, min, max):
+        self.assertLess(wait, max)
+        self.assertGreaterEqual(wait, min)
+
+    def test_wait_chain(self):
+        r = Retrying(wait=tenacity.wait_chain(
+            *[tenacity.wait_fixed(1) for i in six.moves.range(2)] +
+            [tenacity.wait_fixed(4) for i in six.moves.range(2)] +
+            [tenacity.wait_fixed(8) for i in six.moves.range(1)]))
+
+        for i in six.moves.range(10):
+            w = r.wait(i, 1)
+            if i < 2:
+                self._assert_range(w, 1, 2)
+            elif i < 4:
+                self._assert_range(w, 4, 5)
+            else:
+                self._assert_range(w, 8, 9)
+
 
 class TestRetryConditions(unittest.TestCase):
 

--- a/tenacity/wait.py
+++ b/tenacity/wait.py
@@ -69,6 +69,32 @@ class wait_combine(object):
             self.wait_funcs))
 
 
+class wait_chain(object):
+    """Chain two or more waiting strategies.
+
+    If all strategies are exhausted, the very last strategy is used
+    thereafter.
+
+    For example::
+
+        @retry(wait=wait_chain(*[wait_fixed(1000) for i in range(3)] +
+                               [wait_fixed(2000) for j in range(5)] +
+                               [wait_fixed(5000) for k in range(4)))
+        def wait_chained():
+            print("Wait 1s for 3 attempts, 2s for 5 attempts and 5s
+                   thereafter.")
+    """
+
+    def __init__(self, *strategies):
+        self.strategies = list(strategies)
+
+    def __call__(self, previous_attempt_number, delay_since_first_attempt_ms):
+        wait_func = self.strategies[0]
+        if len(self.strategies) > 1:
+            self.strategies.pop(0)
+        return wait_func(previous_attempt_number, delay_since_first_attempt_ms)
+
+
 class wait_incrementing(object):
     """Wait an incremental amount of time after each attempt.
 


### PR DESCRIPTION
One PR I had in retrying [1] proposed to support the notion of
"stepped wait". This patch adds stepping support by introducing
a new combined step function that wraps 1 or more wait fns to
produced a "stepped queue" of wait fns.

This approach solves [1] and also is reusable.

[1] https://github.com/rholder/retrying/pull/51