### PR TITLE
Fix reraise when no exception

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -174,7 +174,7 @@ class Retrying(object):
                 delay_since_first_attempt
             if self.stop(attempt_number, delay_since_first_attempt):
                 if self.reraise:
-                    raise fut.result()
+                    raise RetryError(fut).reraise()
                 six.raise_from(RetryError(fut), fut.exception())
 
             if self.wait:

--- a/tenacity/tests/test_tenacity.py
+++ b/tenacity/tests/test_tenacity.py
@@ -481,5 +481,18 @@ class TestReraiseExceptions(unittest.TestCase):
         self.assertRaises(tenacity.RetryError, _reraised_mock_fn)
         self.assertEqual(2, len(calls))
 
+    def test_reraise_no_exception(self):
+        calls = []
+
+        @retry(wait=tenacity.wait_fixed(0.1),
+               stop=tenacity.stop_after_attempt(2),
+               retry=lambda x: True,
+               reraise=True)
+        def _mock_fn():
+            calls.append('x')
+
+        self.assertRaises(tenacity.RetryError, _mock_fn)
+        self.assertEqual(2, len(calls))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
https://github.com/jd/tenacity/pull/27 introduced a bug
whereupon if a retry callable doesn't raise and Retrying has
its self.reraise set to True, a TypeError will be raised because
we try to raise something that's not an exception class.

This fixes that issue and adds a UT for it.

[1] https://github.com/jd/tenacity/pull/27