### PR TITLE
Fix typo in retry_if_exception example

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -140,7 +140,7 @@ exceptions, as in the cases here.
     def might_io_error():
         print "Retry forever with no wait if an IOError occurs, raise any other errors"
 
-    @retry(retry_on_exception=retry_if_io_error)
+    @retry(retry=retry_if_exception(retry_if_io_error))
     def only_raise_retry_error_when_not_io_error():
         print "Retry forever with no wait if an IOError occurs, raise any other errors wrapped in RetryError"
 
@@ -171,7 +171,7 @@ We can also combine several conditions:
 Any combination of stop, wait, etc. is also supported to give you the freedom
 to mix and match.
 
-It's also possible to retry explicitely at any time by raising the `TryAgain`
+It's also possible to retry explicitly at any time by raising the `TryAgain`
 exception:
 
 .. code-block:: python


### PR DESCRIPTION
Besides the change, which is trivial, I have an additional question: in the print statement within the only_raise_retry_error_when_not_io_error function (lines 143-145) it is mentioned, that the function wraps in RetryError any other errors, but it seems to be incorrect, isn't it? As my experiments show, errors are not wrapped. By the way, is there currently any way to use something similar to wrap_exception as in retrying.retry?