### PR TITLE
Retry coroutines

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -44,6 +44,7 @@ Features
 - Specify wait condition (i.e. exponential backoff sleeping between attempts)
 - Customize retrying on Exceptions
 - Customize retrying on expected returned result
+- Retry on coroutines
 
 
 Installation
@@ -215,6 +216,16 @@ You can access the statistics about the retry made over a function by using the
         pass
 
     print(raise_my_exception.retry.statistics)
+
+
+Finally, ``retry`` works also on asyncio coroutines. Sleeps are done
+asynchronously too.
+
+.. code-block:: python
+
+    @retry
+    async def my_async_function(loop):
+        await loop.getaddrinfo('8.8.8.8', 53)
 
 
 Contribute

--- a/tenacity/async.py
+++ b/tenacity/async.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Étienne Bersac
+# Copyright 2016 Julien Danjou
+# Copyright 2016 Joshua Harlow
+# Copyright 2013-2014 Ray Holder
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import sys
+
+from tenacity import BaseRetrying
+from tenacity import DoAttempt
+from tenacity import DoSleep
+from tenacity import NO_RESULT
+
+
+class AsyncRetrying(BaseRetrying):
+    @asyncio.coroutine
+    def call(self, fn, *args, **kwargs):
+        self.begin(fn)
+
+        result = NO_RESULT
+        exc_info = None
+
+        while True:
+            do = self.iter(result=result, exc_info=exc_info)
+            if isinstance(do, DoAttempt):
+                try:
+                    result = yield from fn(*args, **kwargs)
+                    exc_info = None
+                    continue
+                except Exception:
+                    result = NO_RESULT
+                    exc_info = sys.exc_info()
+                    continue
+            elif isinstance(do, DoSleep):
+                result = NO_RESULT
+                exc_info = None
+                yield from asyncio.sleep(do)
+            else:
+                return do

--- a/tenacity/tests/test_async.py
+++ b/tenacity/tests/test_async.py
@@ -1,0 +1,53 @@
+# coding: utf-8
+# Copyright 2016 Étienne Bersac
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import unittest
+
+import six
+
+from tenacity import retry
+from tenacity.tests.test_tenacity import NoIOErrorAfterCount
+
+
+def asynctest(callable_):
+    callable_ = asyncio.coroutine(callable_)
+
+    @six.wraps(callable_)
+    def wrapper(*a, **kw):
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(callable_(*a, **kw))
+
+    return wrapper
+
+
+@retry
+@asyncio.coroutine
+def _retryable_coroutine(thing):
+    yield from asyncio.sleep(0.00001)
+    thing.go()
+
+
+class TestAsync(unittest.TestCase):
+    @asynctest
+    def test_retry(self):
+        assert asyncio.iscoroutinefunction(_retryable_coroutine)
+        thing = NoIOErrorAfterCount(5)
+        yield from _retryable_coroutine(thing)
+        assert thing.counter == thing.count
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,9 @@ pypy = pypy
 usedevelop = True
 sitepackages = False
 deps = nose
-commands = python setup.py nosetests
+commands =
+    py{27,py}: python setup.py nosetests --ignore-files '.*async.py'
+    py3{4,5}: python setup.py nosetests
 
 [testenv:pep8]
 deps = hacking>=0.12,<0.13


### PR DESCRIPTION
Hi,

This PR ports https://github.com/rholder/retrying/pull/64 to tenacity. Thanks for the fork. The codebase is really clean.

It's a bit tricky to implement retry on coroutines. I did this by extracting the calling (aka attempt) and sleep logic from the retry control loop. This is done by using a generator. The control loop generate instructions (attempt, sleep or return), it's up to the wrapping code to do the actual IO, asynchronously or not.

I'm actually not very proud of this. Supporting old python versions and sync/async is a bit hackish. I'd be glad to hear your opinion on this contribution. Until it's mergeable, i wish :)

Regards,