### PR TITLE
Run flake8 only with latest python

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,10 @@
 envlist = py27,py34,py35,pep8,pypy
 
 [tox:travis]
-2.7 = pep8,py27
-3.4 = pep8,py34
+2.7 = py27
+3.4 = py34
 3.5 = pep8,py35
-pypy = pep8,pypy
+pypy = pypy
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
Hi,

I suggest to run flake8 with latest python version. This mean we do not use flake8 to check py2 compatibility, but only nosetests.

This allow to decouple validation of compatibility and code style.

Extracted from #37 