### PR TITLE
Added a retry_if_not_result class for convenience.

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -35,6 +35,7 @@ from .retry import retry_always  # noqa
 from .retry import retry_any  # noqa
 from .retry import retry_if_exception  # noqa
 from .retry import retry_if_exception_type  # noqa
+from .retry import retry_if_not_result  # noqa
 from .retry import retry_if_result  # noqa
 from .retry import retry_never  # noqa
 

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -37,7 +37,6 @@ from .retry import retry_if_exception  # noqa
 from .retry import retry_if_exception_type  # noqa
 from .retry import retry_if_not_result  # noqa
 from .retry import retry_if_result  # noqa
-from .retry import retry_if_not_result  # noqa
 from .retry import retry_never  # noqa
 
 # Import all built-in stop strategies for easier usage.

--- a/tenacity/retry.py
+++ b/tenacity/retry.py
@@ -83,6 +83,17 @@ class retry_if_result(retry_base):
             return self.predicate(attempt.result())
 
 
+class retry_if_not_result(retry_base):
+    """Retries if the result refutes a predicate."""
+
+    def __init__(self, predicate):
+        self.predicate = predicate
+
+    def __call__(self, attempt):
+        if not attempt.failed:
+            return not self.predicate(attempt.result())
+
+
 class retry_any(retry_base):
     """Retries if any of the retries condition is valid."""
 

--- a/tenacity/tests/test_tenacity.py
+++ b/tenacity/tests/test_tenacity.py
@@ -235,6 +235,16 @@ class TestWaitConditions(unittest.TestCase):
 
 class TestRetryConditions(unittest.TestCase):
 
+    def test_retry_if_result(self):
+        r = (tenacity.retry_if_result(lambda x: x == 1))
+        self.assertTrue(r(tenacity.Future.construct(1, 1, False)))
+        self.assertFalse(r(tenacity.Future.construct(1, 2, False)))
+
+    def test_retry_if_not_result(self):
+        r = (tenacity.retry_if_not_result(lambda x: x == 1))
+        self.assertTrue(r(tenacity.Future.construct(1, 2, False)))
+        self.assertFalse(r(tenacity.Future.construct(1, 1, False)))
+
     def test_retry_any(self):
         r = tenacity.retry_any(
             tenacity.retry_if_result(lambda x: x == 1),


### PR DESCRIPTION
I found myself needing to create a wrapper function or lambda wrapper to use built in functions from other libraries as the predicate in the retry_if_result function. Creating this retry_if_not_result class lets me (and hopefully others) write slightly cleaner code.