### PR TITLE
Add RetryingContext class (A)

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -269,6 +269,7 @@ class RetryingContext(Retrying):
 
   def __exit__(self, exc_type, exc_val, exc_tb):
     # If we returned True here, any exception inside the with block would be suppressed!
+    return False
 
 class Future(futures.Future):
     """Encapsulates a (future or past) attempted call to a target function."""

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -249,6 +249,26 @@ class Retrying(BaseRetrying):
 
     __call__ = call
 
+class RetryingContext(Retrying):
+  """A classic context manager is NOT able to suspend execution in its enter and exit methods."""
+
+  def __init__(self, f, **kwargs):
+    super(RetryingContext, self).__init__(**kwargs)
+    self.f = f
+
+  def __enter__(self):
+    r = self
+    f = self.f
+
+    @six.wraps(f)
+    def wrapped_f(*args, **kw):
+      return r.call(f, *args, **kw)
+
+    wrapped_f.retry = r
+    return wrapped_f
+
+  def __exit__(self, exc_type, exc_val, exc_tb):
+    # If we returned True here, any exception inside the with block would be suppressed!
 
 class Future(futures.Future):
     """Encapsulates a (future or past) attempted call to a target function."""


### PR DESCRIPTION
This implementation does not support AsyncRetrying.
See Issue #48

Example:
```python
with RetryingContext(open) as open:
  with open('filename.txt', 'r') as file:
    ...
```

**Flow:** ContextManager(func, retry_opts) -> retriable_func(func_params) -> func_result -> ContextManager -> file

Outputs a context manager that returns `retriable_func` on `__enter__`.