### PR TITLE
Add RetryingContext class (B)

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -264,6 +264,7 @@ class RetryingContext(object):
     else:
       r = Retrying(*self.args, **self.kwargs)
 
+    @six.wraps(f)
     def wrapped_fn(*args, **kw):
       return r.call(f, *args, **kw)
 
@@ -271,7 +272,8 @@ class RetryingContext(object):
     return wrapped_f
 
   def __exit__(self, exc_type, exc_val, exc_tb):
-    # If we returned True here, any exception inside the with block would be suppressed!   
+    # If we returned True here, any exception inside the with block would be suppressed!
+    return False
 
 
 class Future(futures.Future):

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -249,6 +249,30 @@ class Retrying(BaseRetrying):
 
     __call__ = call
 
+class RetryingContext(object):
+  """A classic context manager is NOT able to suspend execution in its enter and exit methods."""
+
+  def __init__(self, f, *args, **kwargs):
+    self.f = f
+    self.args = args
+    self.kwargs = kwargs
+
+  def __enter__(self):
+    f = self.f
+    if asyncio and asyncio.iscoroutinefunction(f):
+      r = AsyncRetrying(*self.args, **self.kwargs)
+    else:
+      r = Retrying(*self.args, **self.kwargs)
+
+    def wrapped_fn(*args, **kw):
+      return r.call(f, *args, **kw)
+
+    wrapped_f.retry = r
+    return wrapped_f
+
+  def __exit__(self, exc_type, exc_val, exc_tb):
+    # If we returned True here, any exception inside the with block would be suppressed!   
+
 
 class Future(futures.Future):
     """Encapsulates a (future or past) attempted call to a target function."""


### PR DESCRIPTION
Alternative implementation with support for AsyncRetrying.

See Issue #48

Example:
```python
with RetryingContext(open) as open:
  with open('filename.txt', 'r') as file:
    ...

with RetryingContext(asyncio.coroutine(open)) as open:
  with (yield from open('filename.txt', 'r')) as file:
     ...
```

**Flow:** ContextManager(func) -> retriable_func(func_args) -> func_result -> ContextManager -> file
**Async Flow:** ContextManager(async_func) -> async_retriable_func(func_args) -> func_result -> ContextManager -> file

Outputs a context manager that returns `retriable_func` or `async_retriable_func` on `__enter__`.
Awaiting of `func_result` from the `async_retriable_func` is managed externally by the user.