### PR TITLE
Wrap callable into coroutine in AsyncRetrying

### DIFF
--- a/tenacity/async.py
+++ b/tenacity/async.py
@@ -28,6 +28,8 @@ from tenacity import NO_RESULT
 class AsyncRetrying(BaseRetrying):
     @asyncio.coroutine
     def call(self, fn, *args, **kwargs):
+        fn = (fn if asyncio.iscoroutinefunction(fn)
+                      else asyncio.coroutine(fn))
         self.begin(fn)
 
         result = NO_RESULT


### PR DESCRIPTION
In the situation of having legacy libraries within an asyncio stack, it is more convenient for `AsyncRetrying` to check that a coroutine is passed in to avoid silly `object not iterable` errors.