### PR TITLE
feat: added wait_full_jitter

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -51,6 +51,7 @@ from .wait import wait_chain  # noqa
 from .wait import wait_combine  # noqa
 from .wait import wait_exponential  # noqa
 from .wait import wait_fixed  # noqa
+from .wait import wait_full_jitter  # noqa
 from .wait import wait_incrementing  # noqa
 from .wait import wait_none  # noqa
 from .wait import wait_random  # noqa

--- a/tenacity/tests/test_tenacity.py
+++ b/tenacity/tests/test_tenacity.py
@@ -217,6 +217,10 @@ class TestWaitConditions(unittest.TestCase):
         self.assertLess(wait, max)
         self.assertGreaterEqual(wait, min)
 
+    def _assert_inclusive_range(self, wait, low, high):
+        self.assertLessEqual(wait, high)
+        self.assertGreaterEqual(wait, low)
+
     def test_wait_chain(self):
         r = Retrying(wait=tenacity.wait_chain(
             *[tenacity.wait_fixed(1) for i in six.moves.range(2)] +
@@ -231,6 +235,51 @@ class TestWaitConditions(unittest.TestCase):
                 self._assert_range(w, 4, 5)
             else:
                 self._assert_range(w, 8, 9)
+
+    def test_wait_full_jitter(self):
+        fn = tenacity.wait_full_jitter(0.5, 60.0)
+
+        for _ in six.moves.range(1000):
+            self._assert_inclusive_range(fn(0, 0), 0, 0.5)
+            self._assert_inclusive_range(fn(1, 0), 0, 1.0)
+            self._assert_inclusive_range(fn(2, 0), 0, 2.0)
+            self._assert_inclusive_range(fn(3, 0), 0, 4.0)
+            self._assert_inclusive_range(fn(4, 0), 0, 8.0)
+            self._assert_inclusive_range(fn(5, 0), 0, 16.0)
+            self._assert_inclusive_range(fn(6, 0), 0, 32.0)
+            self._assert_inclusive_range(fn(7, 0), 0, 60.0)
+            self._assert_inclusive_range(fn(8, 0), 0, 60.0)
+            self._assert_inclusive_range(fn(9, 0), 0, 60.0)
+
+        fn = tenacity.wait_full_jitter(10, 5)
+        for _ in six.moves.range(1000):
+            self._assert_inclusive_range(fn(0, 0), 0.00, 5.00)
+
+        # Default arguments exist
+        fn = tenacity.wait_full_jitter()
+        fn(0, 0)
+
+    def test_wait_full_jitter_statistically(self):
+        fn = tenacity.wait_full_jitter(0.5, 60.0)
+
+        attempt = []
+        for i in six.moves.range(10):
+            attempt.append(
+                [fn(i, 0) for _ in six.moves.range(4000)]
+            )
+
+        mean = lambda lst: float(sum(lst)) / float(len(lst))
+
+        self._assert_inclusive_range(mean(attempt[0]),  0.20,  0.30)
+        self._assert_inclusive_range(mean(attempt[1]),  0.35,  0.65)
+        self._assert_inclusive_range(mean(attempt[2]),  0.75,  1.25)
+        self._assert_inclusive_range(mean(attempt[3]),  1.75,  3.25)
+        self._assert_inclusive_range(mean(attempt[4]),  3.50,  5.50)
+        self._assert_inclusive_range(mean(attempt[5]),  7.00,  9.00)
+        self._assert_inclusive_range(mean(attempt[6]), 14.00, 18.00)
+        self._assert_inclusive_range(mean(attempt[7]), 28.00, 34.00)
+        self._assert_inclusive_range(mean(attempt[8]), 28.00, 34.00)
+        self._assert_inclusive_range(mean(attempt[9]), 28.00, 34.00)
 
 
 class TestRetryConditions(unittest.TestCase):


### PR DESCRIPTION
Hi,

I've implemented a wait strategy based on the results of this Amazon Architecture Blog:

https://www.awsarchitectureblog.com/2015/03/backoff.html

The Full Jitter strategy attempts to prevent synchronous clusters
from forming in distributed systems by combining exponential backoff
with random jitter. This differs from other strategies as jitter isn't
added to the exponentially increasing sleep time, rather the time is
computed is uniformly random between zero and the exponential point.

Excerpted from the above blog:

      sleep = random_between(0, min(cap, base * 2 ** attempt))

A competing algorithm called "Decorrelated Jitter" is competitive
and in some circumstances may be better. c.f. the above blog for
details.

This is a little bit of a hack because it would be possible to implement this by
making `wait_random` take a function or integer instead of only integers. That would
allow for composing `wait_exponential` and `wait_random` to achieve this effect.

Hope you find this helpful!
Will
