### PR TITLE
Experiment: Functionalizing all Arguments

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -51,6 +51,7 @@ from .wait import wait_chain  # noqa
 from .wait import wait_combine  # noqa
 from .wait import wait_exponential  # noqa
 from .wait import wait_fixed  # noqa
+from .wait import wait_full_jitter  # noqa
 from .wait import wait_incrementing  # noqa
 from .wait import wait_none  # noqa
 from .wait import wait_random  # noqa

--- a/tenacity/tests/test_tenacity.py
+++ b/tenacity/tests/test_tenacity.py
@@ -217,6 +217,10 @@ class TestWaitConditions(unittest.TestCase):
         self.assertLess(wait, max)
         self.assertGreaterEqual(wait, min)
 
+    def _assert_inclusive_range(self, wait, low, high):
+        self.assertLessEqual(wait, high)
+        self.assertGreaterEqual(wait, low)
+
     def test_wait_chain(self):
         r = Retrying(wait=tenacity.wait_chain(
             *[tenacity.wait_fixed(1) for i in six.moves.range(2)] +
@@ -231,6 +235,64 @@ class TestWaitConditions(unittest.TestCase):
                 self._assert_range(w, 4, 5)
             else:
                 self._assert_range(w, 8, 9)
+
+    def test_wait_full_jitter(self):
+        fn = tenacity.wait_full_jitter(0.5, 60.0)
+
+        for _ in six.moves.range(1000):
+            self._assert_inclusive_range(fn(0, 0), 0, 0.5)
+            self._assert_inclusive_range(fn(1, 0), 0, 1.0)
+            self._assert_inclusive_range(fn(2, 0), 0, 2.0)
+            self._assert_inclusive_range(fn(3, 0), 0, 4.0)
+            self._assert_inclusive_range(fn(4, 0), 0, 8.0)
+            self._assert_inclusive_range(fn(5, 0), 0, 16.0)
+            self._assert_inclusive_range(fn(6, 0), 0, 32.0)
+            self._assert_inclusive_range(fn(7, 0), 0, 60.0)
+            self._assert_inclusive_range(fn(8, 0), 0, 60.0)
+            self._assert_inclusive_range(fn(9, 0), 0, 60.0)
+
+        def test_assertions(fn):
+            failed = True
+            try:
+                fn()
+                failed = False
+            except AssertionError:
+                pass
+            finally:
+                assert failed
+
+        test_assertions(lambda: tenacity.wait_full_jitter(-1, 0))
+        test_assertions(lambda: tenacity.wait_full_jitter(0, -1))
+
+        fn = tenacity.wait_full_jitter(10, 5)
+        for _ in six.moves.range(1000):
+            self._assert_inclusive_range(fn(0, 0), 0.00, 5.00)
+
+        # Default arguments exist
+        fn = tenacity.wait_full_jitter()
+        fn(0, 0)
+
+    def test_wait_full_jitter_statistically(self):
+        fn = tenacity.wait_full_jitter(0.5, 60.0)
+
+        attempt = []
+        for i in six.moves.range(10):
+            attempt.append(
+                [fn(i, 0) for _ in six.moves.range(4000)]
+            )
+
+        mean = lambda lst: float(sum(lst)) / float(len(lst))
+
+        self._assert_inclusive_range(mean(attempt[0]),  0.20,  0.30)
+        self._assert_inclusive_range(mean(attempt[1]),  0.35,  0.65)
+        self._assert_inclusive_range(mean(attempt[2]),  0.75,  1.25)
+        self._assert_inclusive_range(mean(attempt[3]),  1.75,  3.25)
+        self._assert_inclusive_range(mean(attempt[4]),  3.50,  5.50)
+        self._assert_inclusive_range(mean(attempt[5]),  7.00,  9.00)
+        self._assert_inclusive_range(mean(attempt[6]), 14.00, 18.00)
+        self._assert_inclusive_range(mean(attempt[7]), 28.00, 34.00)
+        self._assert_inclusive_range(mean(attempt[8]), 28.00, 34.00)
+        self._assert_inclusive_range(mean(attempt[9]), 28.00, 34.00)
 
 
 class TestRetryConditions(unittest.TestCase):

--- a/tenacity/wait.py
+++ b/tenacity/wait.py
@@ -146,3 +146,47 @@ class wait_exponential(wait_base):
         except OverflowError:
             return self.max
         return max(0, min(result, self.max))
+
+
+class wait_full_jitter(wait_base):
+    """Random wait with exponentially widening window.
+
+    Wait strategy based on the results of this Amazon Architecture Blog:
+
+    https://www.awsarchitectureblog.com/2015/03/backoff.html
+
+    The Full Jitter strategy attempts to prevent synchronous clusters
+    from forming in distributed systems by combining exponential backoff
+    with random jitter. This differs from other strategies as jitter isn't
+    added to the exponentially increasing sleep time, rather the time is
+    computed is uniformly random between zero and the exponential point.
+
+    Excerpted from the above blog:
+        sleep = random_between(0, min(cap, base * 2 ** attempt))
+
+    A competing algorithm called "Decorrelated Jitter" is competitive
+    and in some circumstances may be better. c.f. the above blog for
+    details.
+
+    Example:
+        wait_full_jitter(0.5, 60) # initial window 0.5sec, max 60sec timeout
+
+    Optional:
+        base: (float) starting jitter window size in seconds.
+            Equals 'base' above.
+        max_timeout_sec: (float, default 60.0) Maximum time to wait.
+            Equals 'cap' above.
+
+    Returns: (float) time to sleep in seconds
+    """
+    def __init__(self, base=0.5, max_timeout_sec=60.0):
+        super(self.__class__, self).__init__()
+
+        assert base >= 0
+        assert max_timeout_sec >= 0
+
+        self.exp = wait_exponential(multiplier=base, max=max_timeout_sec)
+
+    def __call__(self, previous_attempt_number, delay_since_first_attempt):
+        high = self.exp(previous_attempt_number, delay_since_first_attempt)
+        return random.uniform(0, high)

--- a/tenacity/wait.py
+++ b/tenacity/wait.py
@@ -21,6 +21,12 @@ import six
 
 from tenacity import _utils
 
+def fn(x): 
+    """Creates a thunk"""
+    if callable(x):
+        return x
+    else:
+        return lambda atmpt_ct, delay: x    
 
 @six.add_metaclass(abc.ABCMeta)
 class wait_base(object):
@@ -44,10 +50,10 @@ class wait_fixed(wait_base):
     """Wait strategy that waits a fixed amount of time between each retry."""
 
     def __init__(self, wait):
-        self.wait_fixed = wait
+        self.wait_fixed = fn(wait)
 
     def __call__(self, previous_attempt_number, delay_since_first_attempt):
-        return self.wait_fixed
+        return self.wait_fixed(previous_attempt_number, delay_since_first_attempt)
 
 
 class wait_none(wait_fixed):
@@ -61,14 +67,13 @@ class wait_random(wait_base):
     """Wait strategy that waits a random amount of time between min/max."""
 
     def __init__(self, min=0, max=1):
-        self.wait_random_min = min
-        self.wait_random_max = max
+        self.wait_random_min = fn(min)
+        self.wait_random_max = fn(max)
 
     def __call__(self, previous_attempt_number, delay_since_first_attempt):
-        return (self.wait_random_min
-                + (random.random()
-                   * (self.wait_random_max - self.wait_random_min)))
-
+        wait_min = self.wait_random_min(previous_attempt_number, delay_since_first_attempt)
+        wait_max = self.wait_random_max(previous_attempt_number, delay_since_first_attempt)
+        return random.uniform(wait_min, wait_max)
 
 class wait_combine(wait_base):
     """Combine several waiting strategies."""
@@ -116,16 +121,19 @@ class wait_incrementing(wait_base):
     """
 
     def __init__(self, start=0, increment=100, max=_utils.MAX_WAIT):
-        self.start = start
-        self.increment = increment
-        self.max = max
+        self.start = fn(start)
+        self.increment = fn(increment)
+        self.max = fn(max)
 
     def __call__(self, previous_attempt_number, delay_since_first_attempt):
-        result = self.start + (
-            self.increment * (previous_attempt_number - 1)
-        )
-        return max(0, min(result, self.max))
+        start = self.start(previous_attempt_number, delay_since_first_attempt)
+        incr = self.increment(previous_attempt_number, delay_since_first_attempt)
+        end = self.max(previous_attempt_number, delay_since_first_attempt)
 
+        result = start + (
+            incr * (previous_attempt_number - 1)
+        )
+        return max(0, min(result, end))
 
 class wait_exponential(wait_base):
     """Wait strategy that applies exponential backoff.
@@ -135,58 +143,22 @@ class wait_exponential(wait_base):
     """
 
     def __init__(self, multiplier=1, max=_utils.MAX_WAIT, exp_base=2):
-        self.multiplier = multiplier
-        self.max = max
-        self.exp_base = exp_base
+        self.multiplier = fn(multiplier)
+        self.max = fn(max)
+        self.exp_base = fn(exp_base)
 
     def __call__(self, previous_attempt_number, delay_since_first_attempt):
+        exp_base = self.exp_base(previous_attempt_number, delay_since_first_attempt) 
+        multiplier = self.multiplier(previous_attempt_number, delay_since_first_attempt)
+        ceil = self.max(previous_attempt_number, delay_since_first_attempt)
         try:
-            exp = self.exp_base ** previous_attempt_number
-            result = self.multiplier * exp
+            exp = exp_base ** previous_attempt_number
+            result = multiplier * exp
         except OverflowError:
-            return self.max
-        return max(0, min(result, self.max))
+            return ceil
+        return max(0, min(result, ceil))
 
-
-class wait_full_jitter(wait_base):
-    """Random wait with exponentially widening window.
-
-    Wait strategy based on the results of this Amazon Architecture Blog:
-
-    https://www.awsarchitectureblog.com/2015/03/backoff.html
-
-    The Full Jitter strategy attempts to prevent synchronous clusters
-    from forming in distributed systems by combining exponential backoff
-    with random jitter. This differs from other strategies as jitter isn't
-    added to the exponentially increasing sleep time, rather the time is
-    computed is uniformly random between zero and the exponential point.
-
-    Excerpted from the above blog:
-        sleep = random_between(0, min(cap, base * 2 ** attempt))
-
-    A competing algorithm called "Decorrelated Jitter" is competitive
-    and in some circumstances may be better. c.f. the above blog for
-    details.
-
-    Example:
-        wait_full_jitter(0.5, 60) # initial window 0.5sec, max 60sec timeout
-
-    Optional:
-        base: (float) starting jitter window size in seconds.
-            Equals 'base' above.
-        max_timeout_sec: (float, default 60.0) Maximum time to wait.
-            Equals 'cap' above.
-
-    Returns: (float) time to sleep in seconds
-    """
-    def __init__(self, base=0.5, max_timeout_sec=60.0):
-        super(self.__class__, self).__init__()
-
-        assert base >= 0
-        assert max_timeout_sec >= 0
-
-        self.exp = wait_exponential(multiplier=base, max=max_timeout_sec)
-
-    def __call__(self, previous_attempt_number, delay_since_first_attempt):
-        high = self.exp(previous_attempt_number, delay_since_first_attempt)
-        return random.uniform(0, high)
+def wait_full_jitter(base=0.5, cap=60):
+    assert base >= 0
+    assert cap >= 0
+    return wait_random(0, wait_exponential(base, cap))


### PR DESCRIPTION
Here's an experiment that might be interesting to you. This PR isn't cleaned up for merge, but it shows a little of what you can do if all wait functions take a function as an argument.

I've implemented the `wait_full_jitter` function from #70 as composed functions. It's a little messy, but mostly because of the length of the names of `previous_attempt_number` and `delay_since_first_attempt`. 

Let me know what you think.
- Will