### PR TITLE
Retry until exception type

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -37,6 +37,7 @@ from .retry import retry_if_exception_type  # noqa
 from .retry import retry_if_not_result  # noqa
 from .retry import retry_if_result  # noqa
 from .retry import retry_never  # noqa
+from .retry import retry_unless_exception_type  # noqa
 
 # Import all nap strategies for easier usage.
 from .nap import sleep  # noqa

--- a/tenacity/retry.py
+++ b/tenacity/retry.py
@@ -64,12 +64,27 @@ class retry_if_exception(retry_base):
 
 
 class retry_if_exception_type(retry_if_exception):
-    """Retries if an exception has been raised of a certain type."""
+    """Retries if an exception has been raised of one or more types."""
 
     def __init__(self, exception_types=Exception):
         self.exception_types = exception_types
         super(retry_if_exception_type, self).__init__(
             lambda e: isinstance(e, exception_types))
+
+
+class retry_unless_exception_type(retry_if_exception):
+    """Retries until an exception is raised of one or more types."""
+
+    def __init__(self, exception_types=Exception):
+        self.exception_types = exception_types
+        super(retry_unless_exception_type, self).__init__(
+            lambda e: not isinstance(e, exception_types))
+
+    def __call__(self, attempt):
+        # always retry if no exception was raised
+        if not attempt.failed:
+            return True
+        return self.predicate(attempt.exception())
 
 
 class retry_if_result(retry_base):


### PR DESCRIPTION
Add complement for retry_if_exception_type, which performs the inverse operation of ignoring all results and exceptions until an exception is hit.

Feel free to change name of the class. Also, I understand if this is superfluous and is closed. I needed it in a very specific use case and it may not be useful to others.