### PR TITLE
Document random exponential backoff strategy

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -136,6 +136,16 @@ remote endpoints.
         print("Wait at least 3 seconds, and add up to 2 seconds of random delay")
         raise Exception
 
+When multiple processes are in contention for a shared resource, exponentially
+increasing jitter helps minimise collisions.
+
+.. code-block:: python
+
+    @retry(wait=wait_random_exponential(multiplier=1, max=60))
+    def wait_exponential_jitter():
+        print("Randomly wait up to 2^x * 1 seconds between each retry until the range reaches 60 seconds, then randomly up to 60 seconds afterwards")
+        raise Exception
+
 
 Sometimes it's necessary to build a chain of backoffs.
 

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -55,10 +55,11 @@ from .wait import wait_chain  # noqa
 from .wait import wait_combine  # noqa
 from .wait import wait_exponential  # noqa
 from .wait import wait_fixed  # noqa
-from .wait import wait_full_jitter  # noqa
 from .wait import wait_incrementing  # noqa
 from .wait import wait_none  # noqa
 from .wait import wait_random  # noqa
+from .wait import wait_random_exponential  # noqa
+from .wait import wait_random_exponential as wait_full_jitter  # noqa
 
 # Import all built-in before strategies for easier usage.
 from .before import before_log  # noqa

--- a/tenacity/tests/test_tenacity.py
+++ b/tenacity/tests/test_tenacity.py
@@ -236,8 +236,8 @@ class TestWaitConditions(unittest.TestCase):
             else:
                 self._assert_range(w, 8, 9)
 
-    def test_wait_full_jitter(self):
-        fn = tenacity.wait_full_jitter(0.5, 60.0)
+    def test_wait_random_exponential(self):
+        fn = tenacity.wait_random_exponential(0.5, 60.0)
 
         for _ in six.moves.range(1000):
             self._assert_inclusive_range(fn(0, 0), 0, 0.5)
@@ -251,16 +251,16 @@ class TestWaitConditions(unittest.TestCase):
             self._assert_inclusive_range(fn(8, 0), 0, 60.0)
             self._assert_inclusive_range(fn(9, 0), 0, 60.0)
 
-        fn = tenacity.wait_full_jitter(10, 5)
+        fn = tenacity.wait_random_exponential(10, 5)
         for _ in six.moves.range(1000):
             self._assert_inclusive_range(fn(0, 0), 0.00, 5.00)
 
         # Default arguments exist
-        fn = tenacity.wait_full_jitter()
+        fn = tenacity.wait_random_exponential()
         fn(0, 0)
 
-    def test_wait_full_jitter_statistically(self):
-        fn = tenacity.wait_full_jitter(0.5, 60.0)
+    def test_wait_random_exponential_statistically(self):
+        fn = tenacity.wait_random_exponential(0.5, 60.0)
 
         attempt = []
         for i in six.moves.range(10):

--- a/tenacity/wait.py
+++ b/tenacity/wait.py
@@ -148,7 +148,7 @@ class wait_exponential(wait_base):
         return max(0, min(result, self.max))
 
 
-class wait_full_jitter(wait_exponential):
+class wait_random_exponential(wait_exponential):
     """Random wait with exponentially widening window.
 
     Wait strategy based on the results of this Amazon Architecture Blog:
@@ -169,7 +169,8 @@ class wait_full_jitter(wait_exponential):
     details.
 
     Example:
-        wait_full_jitter(0.5, 60) # initial window 0.5sec, max 60sec timeout
+        wait_random_exponential(0.5, 60) # initial window 0.5sec,
+                                         # max 60sec timeout
 
     Optional:
         base: (float) starting jitter window size in seconds.
@@ -180,6 +181,6 @@ class wait_full_jitter(wait_exponential):
     Returns: (float) time to sleep in seconds
     """
     def __call__(self, previous_attempt_number, delay_since_first_attempt):
-        high = super(wait_full_jitter, self).__call__(
+        high = super(wait_random_exponential, self).__call__(
             previous_attempt_number, delay_since_first_attempt)
         return random.uniform(0, high)


### PR DESCRIPTION
The `wait_full_jitter` strategy is very widely useful (it turns out that I was [implementing the same thing](https://review.openstack.org/#/c/328613/12/heat/engine/sync_point.py) at roughly the same time as the author), but it is not documented in the README and the name requires context to make sense of.

This PR renames the strategy to the hopefully self-explanatory `wait_random_exponential` and documents it better.