### PR TITLE
Don't fall over if an old version of tornado is installed

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -95,7 +95,8 @@ def retry(*dargs, **dkw):
         def wrap(f):
             if asyncio and asyncio.iscoroutinefunction(f):
                 r = AsyncRetrying(*dargs, **dkw)
-            elif tornado and tornado.gen.is_coroutine_function(f):
+            elif tornado and hasattr(tornado.gen, 'is_coroutine_function') \
+                    and tornado.gen.is_coroutine_function(f):
                 r = TornadoRetrying(*dargs, **dkw)
             else:
                 r = Retrying(*dargs, **dkw)

--- a/tenacity/tests/test_tornado.py
+++ b/tenacity/tests/test_tornado.py
@@ -41,6 +41,19 @@ class TestTornado(testing.AsyncTestCase):
     def test_repr(self):
         repr(tornadoweb.TornadoRetrying())
 
+    def test_old_tornado(self):
+        old_attr = gen.is_coroutine_function
+        try:
+            del gen.is_coroutine_function
+
+            # is_coroutine_function was introduced in tornado 4.5;
+            # verify that we don't *completely* fall over on old versions
+            @retry
+            def retryable(thing):
+                pass
+        finally:
+            gen.is_coroutine_function = old_attr
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ sitepackages = False
 deps =
     nose
     sphinx
-    tornado
+    tornado>=4.5
 commands =
     py{27,py}: python setup.py nosetests --ignore-files '.*async.py'
     py3{5,6}: python setup.py nosetests


### PR DESCRIPTION
Related to issue #99 -- even if we don't properly support old versions of tornado, we can do better than raise an `AttributeError` if an old version *just happens* to be installed.