### PR TITLE
Avoid inspect.getargspec deprecation warning

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -27,7 +27,6 @@ try:
 except ImportError:
     tornado = None
 
-import inspect
 import sys
 import threading
 from concurrent import futures
@@ -182,7 +181,7 @@ class BaseRetrying(object):
             return False
         if isinstance(waiter, _wait.wait_base):
             waiter = waiter.__call__
-        waiter_spec = inspect.getargspec(waiter)
+        waiter_spec = _utils.getargspec(waiter)
         return 'last_result' in waiter_spec.args
 
     def __repr__(self):

--- a/tenacity/_utils.py
+++ b/tenacity/_utils.py
@@ -31,9 +31,16 @@ if six.PY2:
         # TODO(harlowja): delete this in future, since its
         # has to repeatedly calculate this crap.
         fut.set_exception_info(tb[1], tb[2])
+
+    def getargspec(func):
+        # This was deprecated in Python 3.
+        return inspect.getargspec(func)
 else:
     def capture(fut, tb):
         fut.set_exception(tb[1])
+
+    def getargspec(func):
+        return inspect.getfullargspec(func)
 
 
 def visible_attrs(obj, attrs=None):


### PR DESCRIPTION
`inspect.getargspec()` was deprecated in Python 3. Use `inspect.getfullargspec()` in Python 3.