### PR TITLE
Fix #110: Documentation page on PyPI has broken formatting

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -17,7 +17,7 @@ It originates from `a fork of retrying
 The simplest use case is retrying a flaky function whenever an `Exception`
 occurs until a value is returned.
 
-.. testcode::
+.. code-block:: python
 
     import random
     from tenacity import retry
@@ -31,7 +31,7 @@ occurs until a value is returned.
 
     print(do_something_unreliable())
 
-.. testoutput::
+.. ::
    :hide:
 
    Awesome sauce!
@@ -60,7 +60,7 @@ To install *tenacity*, simply:
 Examples
 ----------
 
-.. testsetup:: *
+.. code-block:: python
 
     import logging
     from tenacity import *
@@ -71,7 +71,7 @@ Examples
 As you saw above, the default behavior is to retry forever without waiting when
 an exception is raised.
 
-.. testcode::
+.. code-block:: python
 
     @retry
     def never_give_up_never_surrender():
@@ -81,7 +81,7 @@ an exception is raised.
 Let's be a little less persistent and set some boundaries, such as the number
 of attempts before giving up.
 
-.. testcode::
+.. code-block:: python
 
     @retry(stop=stop_after_attempt(7))
     def stop_after_7_attempts():
@@ -91,7 +91,7 @@ of attempts before giving up.
 We don't have all day, so let's set a boundary for how long we should be
 retrying stuff.
 
-.. testcode::
+.. code-block:: python
 
     @retry(stop=stop_after_delay(10))
     def stop_after_10_s():
@@ -100,7 +100,7 @@ retrying stuff.
 
 You can combine several stop conditions by using the `|` operator:
 
-.. testcode::
+.. code-block:: python
 
     @retry(stop=(stop_after_delay(10) | stop_after_attempt(5)))
     def stop_after_10_s_or_5_retries():
@@ -110,7 +110,7 @@ You can combine several stop conditions by using the `|` operator:
 Most things don't like to be polled as fast as possible, so let's just wait 2
 seconds between retries.
 
-.. testcode::
+.. code-block:: python
 
     @retry(wait=wait_fixed(2))
     def wait_2_s():
@@ -119,7 +119,7 @@ seconds between retries.
 
 Some things perform best with a bit of randomness injected.
 
-.. testcode::
+.. code-block:: python
 
     @retry(wait=wait_random(min=1, max=2))
     def wait_random_1_to_2_s():
@@ -129,7 +129,7 @@ Some things perform best with a bit of randomness injected.
 Then again, it's hard to beat exponential backoff when retrying distributed
 services and other remote endpoints.
 
-.. testcode::
+.. code-block:: python
 
     @retry(wait=wait_exponential(multiplier=1, max=10))
     def wait_exponential_1():
@@ -141,7 +141,7 @@ Then again, it's also hard to beat combining fixed waits and jitter (to
 help avoid thundering herds) when retrying distributed services and other
 remote endpoints.
 
-.. testcode::
+.. code-block:: python
 
     @retry(wait=wait_fixed(3) + wait_random(0, 2))
     def wait_fixed_jitter():
@@ -151,7 +151,7 @@ remote endpoints.
 When multiple processes are in contention for a shared resource, exponentially
 increasing jitter helps minimise collisions.
 
-.. testcode::
+.. code-block:: python
 
     @retry(wait=wait_random_exponential(multiplier=1, max=60))
     def wait_exponential_jitter():
@@ -161,7 +161,7 @@ increasing jitter helps minimise collisions.
 
 Sometimes it's necessary to build a chain of backoffs.
 
-.. testcode::
+.. code-block:: python
 
     @retry(wait=wait_chain(*[wait_fixed(3) for i in range(3)] +
                            [wait_fixed(7) for i in range(2)] +
@@ -173,7 +173,7 @@ Sometimes it's necessary to build a chain of backoffs.
 We have a few options for dealing with retries that raise specific or general
 exceptions, as in the cases here.
 
-.. testcode::
+.. code-block:: python
 
     @retry(retry=retry_if_exception_type(IOError))
     def might_io_error():
@@ -182,7 +182,7 @@ exceptions, as in the cases here.
 
 We can also use the result of the function to alter the behavior of retrying.
 
-.. testcode::
+.. code-block:: python
 
     def is_none_p(value):
         """Return True if value is None"""
@@ -194,7 +194,7 @@ We can also use the result of the function to alter the behavior of retrying.
 
 We can also combine several conditions:
 
-.. testcode::
+.. code-block:: python
 
     def is_none_p(value):
         """Return True if value is None"""
@@ -210,7 +210,7 @@ to mix and match.
 It's also possible to retry explicitly at any time by raising the `TryAgain`
 exception:
 
-.. testcode::
+.. code-block:: python
 
    @retry
    def do_something():
@@ -221,7 +221,7 @@ exception:
 While callables that "timeout" retrying raise a `RetryError` by default,
 we can reraise the last attempt's exception if needed:
 
-.. testcode::
+.. code-block:: python
 
     @retry(reraise=True, stop=stop_after_attempt(3))
     def raise_my_exception():
@@ -236,7 +236,7 @@ we can reraise the last attempt's exception if needed:
 It's possible to execute an action before any attempt of calling the function
 by using the before callback function:
 
-.. testcode::
+.. code-block:: python
 
     logger = logging.getLogger(__name__)
 
@@ -246,7 +246,7 @@ by using the before callback function:
 
 In the same spirit, It's possible to execute after a call that failed:
 
-.. testcode::
+.. code-block:: python
 
     logger = logging.getLogger(__name__)
 
@@ -257,7 +257,7 @@ In the same spirit, It's possible to execute after a call that failed:
 You can access the statistics about the retry made over a function by using the
 `retry` attribute attached to the function and its `statistics` attribute:
 
-.. testcode::
+.. code-block:: python
 
     @retry(stop=stop_after_attempt(3))
     def raise_my_exception():
@@ -270,7 +270,7 @@ You can access the statistics about the retry made over a function by using the
 
     print(raise_my_exception.retry.statistics)
 
-.. testoutput::
+.. ::
    :hide:
 
    ...
@@ -278,7 +278,7 @@ You can access the statistics about the retry made over a function by using the
 You can change the arguments of a retry decorator as needed when calling it by
 using the `retry_with` function attached to the wrapped function:
 
-.. testcode::
+.. code-block:: python
 
     @retry(stop=stop_after_attempt(3))
     def raise_my_exception():
@@ -291,7 +291,7 @@ using the `retry_with` function attached to the wrapped function:
 
     print(raise_my_exception.retry.statistics)
 
-.. testoutput::
+.. ::
    :hide:
 
    ...

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py27,py34,py35,py36,pep8,pypy
+envlist = py27,py34,py35,py36,pep8,pypy,readme
 
 [tox:travis]
 2.7 = py27
 3.5 = py35
-3.6 = pep8,py36
+3.6 = pep8,py36,readme
 pypy = pypy
 
 [testenv]
@@ -29,6 +29,11 @@ deps = flake8
        flake8-rst-docstrings
        flake8-logging-format
 commands = flake8
+
+[testenv:readme]
+deps = 
+    collective.checkdocs
+commands = python setup.py checkdocs
 
 [flake8]
 exclude = .tox,.eggs

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,8 @@ deps = flake8
 commands = flake8
 
 [testenv:readme]
-deps = 
+deps =
+    pygments
     collective.checkdocs
 commands = python setup.py checkdocs
 


### PR DESCRIPTION
use parseable `.. code-block:: python` and `.. ::` for output. Validate readme on CI.