### PR TITLE
Add `license` key to `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 name = tenacity
+license = Apache 2.0
 url = https://github.com/jd/tenacity
 summary = Retry code until it succeeeds
 description-file =


### PR DESCRIPTION
Although it duplicates with the license classifier, the lacking key causes some API to fail to retrieve the package license. The most notable is  [**shields.io**](https://shields.io/): here's how the PyPI version badge looks for your project: 

![PyPI - License](https://img.shields.io/pypi/l/tenacity.svg)

Here's how it should look after this commit is applied:

![PyPI - License](https://img.shields.io/pypi/l/kelctl.svg)