### PR TITLE
Implement before_sleep logging hook

### DIFF
--- a/tenacity/before_sleep.py
+++ b/tenacity/before_sleep.py
@@ -1,0 +1,33 @@
+# Copyright 2016 Julien Danjou
+# Copyright 2016 Joshua Harlow
+# Copyright 2013-2014 Ray Holder
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from tenacity import _utils
+
+
+def before_sleep_nothing(retry_obj, sleep, last_result):
+    """Before call strategy that does nothing."""
+
+
+def before_sleep_log(logger, log_level):
+    """Before call strategy that logs to some logger the attempt."""
+    def log_it(retry_obj, sleep, last_result):
+        logger.log(log_level,
+                   "Retrying %s in %d seconds as it raised %s.",
+                   _utils.get_callback_name(retry_obj.fn),
+                   sleep,
+                   last_result.exception())
+
+    return log_it

--- a/tenacity/tests/test_tenacity.py
+++ b/tenacity/tests/test_tenacity.py
@@ -720,6 +720,27 @@ class TestBeforeAfterAttempts(unittest.TestCase):
 
         self.assertTrue(TestBeforeAfterAttempts._attempt_number is 2)
 
+    def test_before_sleep(self):
+        TestBeforeAfterAttempts._attempt_number = 0
+
+        def _before_sleep(retry_obj, sleep, last_result):
+            self.assertGreater(sleep, 0)
+            TestBeforeAfterAttempts._attempt_number = \
+                retry_obj.statistics['attempt_number']
+
+        @retry(wait=tenacity.wait_fixed(0.1),
+               stop=tenacity.stop_after_attempt(3),
+               before_sleep=_before_sleep)
+        def _test_before_sleep():
+            if TestBeforeAfterAttempts._attempt_number < 2:
+                raise Exception("testing before_sleep_attempts handler")
+            else:
+                pass
+
+        _test_before_sleep()
+
+        self.assertTrue(TestBeforeAfterAttempts._attempt_number is 2)
+
 
 class TestReraiseExceptions(unittest.TestCase):
 


### PR DESCRIPTION
This PR arose from the wish to have the result and the future wait seconds in the ``after`` logging handler. It turned out that modifying this handler is not straight-forward because the wait seconds will only be calculated later.

To ensure backwards compatibility wrt to the ``wait`` function, I propose another handler ``before_sleep`` that will be called whenever a sleep is scheduled and the function will be retried later. For me, this logging hook is essential because I can be informed about the seconds tenacity will wait before retrying.

Related to jd/tenacity#77