### PR TITLE
Add optional retry_error_callback param

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -254,6 +254,25 @@ In the same spirit, It's possible to execute after a call that failed:
     def raise_my_exception():
         raise MyException("Fail")
 
+Similarly, you can call a custom callback function after all retries failed, without raising an exception (or you can re-raise or do anything really)
+
+.. testcode::
+
+    def return_last_value(last_attempt):
+        """return the result of the last call attempt"""
+        return last_attempt.result()
+
+    def is_false(value):
+        """Return True if value is False"""
+        return value is False
+
+    # will return False after trying 3 times to get a different result
+    @retry(stop=stop_after_attempt(3),
+           retry_error_callback=return_last_value,
+           retry=retry_if_result(is_false))
+    def eventually_return_false():
+        return False
+
 You can access the statistics about the retry made over a function by using the
 `retry` attribute attached to the function and its `statistics` attribute:
 

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -150,7 +150,8 @@ class BaseRetrying(object):
                  after=after_nothing,
                  before_sleep=before_sleep_nothing,
                  reraise=False,
-                 retry_error_cls=RetryError):
+                 retry_error_cls=RetryError,
+                 retry_error_callback=None):
         self.sleep = sleep
         self.stop = stop
         self.wait = wait
@@ -165,6 +166,7 @@ class BaseRetrying(object):
         # the prior result.
         self._wait_takes_result = self._waiter_takes_last_result(wait)
         self.retry_error_cls = retry_error_cls
+        self.retry_error_callback = retry_error_callback
 
     def copy(self, sleep=_unset, stop=_unset, wait=_unset,
              retry=_unset, before=_unset, after=_unset, before_sleep=_unset,
@@ -288,6 +290,8 @@ class BaseRetrying(object):
             delay_since_first_attempt
         if self.stop(self.statistics['attempt_number'],
                      delay_since_first_attempt):
+            if self.retry_error_callback:
+                return self.retry_error_callback(fut)
             retry_exc = self.retry_error_cls(fut)
             if self.reraise:
                 raise retry_exc.reraise()


### PR DESCRIPTION
Being able to call a custom function when all retries have failed is useful for a few applications.

* Do nothing (raise no exception without repeated try/except boilerplate)
* Return a default value
* Return the value of the last attempt (if `retry_if_result` for example)
* Really anything you can think to do with the last `Future` object

A couple of these uses were issues on the `retrying` module, which I made a PR to before realizing this is probably a better place for it.