### PR TITLE
Make before_sleep accept call_state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ AUTHORS
 ChangeLog
 .eggs/
 doc/_build
+
+/.pytest_cache

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -22,7 +22,8 @@ master_doc = 'index'
 project = "Tenacity"
 
 extensions = [
-    'sphinx.ext.doctest'
+    'sphinx.ext.doctest',
+    'sphinx.ext.autodoc',
 ]
 
 # -- Options for sphinx.ext.doctest  -----------------------------------------

--- a/tenacity/_asyncio.py
+++ b/tenacity/_asyncio.py
@@ -37,7 +37,8 @@ class AsyncRetrying(BaseRetrying):
     def call(self, fn, *args, **kwargs):
         self.begin(fn)
 
-        call_state = RetryCallState(fn=fn, args=args, kwargs=kwargs)
+        call_state = RetryCallState(
+            retry_object=self, fn=fn, args=args, kwargs=kwargs)
         while True:
             do = self.iter(call_state=call_state)
             if isinstance(do, DoAttempt):

--- a/tenacity/_utils.py
+++ b/tenacity/_utils.py
@@ -132,3 +132,13 @@ class cached_property(object):
             return self
         value = obj.__dict__[self.func.__name__] = self.func(obj)
         return value
+
+
+def _func_takes_call_state(func):
+    if not six.callable(func):
+        return False
+    if not inspect.isfunction(func):
+        # func is a callable object rather than a function
+        func = func.__call__
+    func_spec = getargspec(func)
+    return 'call_state' in func_spec.args

--- a/tenacity/before_sleep.py
+++ b/tenacity/before_sleep.py
@@ -26,11 +26,16 @@ def before_sleep_nothing(call_state, sleep, last_result):
 def before_sleep_log(logger, log_level):
     """Before call strategy that logs to some logger the attempt."""
     def log_it(call_state):
+        if call_state.outcome.failed:
+            verb, value = 'raised', call_state.outcome.exception()
+        else:
+            verb, value = 'returned', call_state.outcome.result()
+
         logger.log(log_level,
-                   "Retrying %s in %d seconds as it raised %s.",
+                   "Retrying %s in %s seconds as it %s %s.",
                    _utils.get_callback_name(call_state.fn),
                    getattr(call_state.next_action, 'sleep'),
-                   call_state.outcome.exception())
+                   verb, value)
     return log_it
 
 

--- a/tenacity/tornadoweb.py
+++ b/tenacity/tornadoweb.py
@@ -35,7 +35,8 @@ class TornadoRetrying(BaseRetrying):
     def call(self, fn, *args, **kwargs):
         self.begin(fn)
 
-        call_state = RetryCallState(fn=fn, args=args, kwargs=kwargs)
+        call_state = RetryCallState(
+            retry_object=self, fn=fn, args=args, kwargs=kwargs)
         while True:
             do = self.iter(call_state=call_state)
             if isinstance(do, DoAttempt):

--- a/tenacity/wait.py
+++ b/tenacity/wait.py
@@ -233,15 +233,6 @@ class wait_random_exponential(wait_exponential):
         return random.uniform(0, high)
 
 
-def _func_takes_call_state(func):
-    if not six.callable(func):
-        return False
-    if isinstance(func, wait_base):
-        func = func.__call__
-    func_spec = _utils.getargspec(func)
-    return 'call_state' in func_spec.args
-
-
 def _func_takes_last_result(waiter):
     if not six.callable(waiter):
         return False
@@ -255,7 +246,7 @@ def _wait_func_accept_call_state(wait_func):
     if not six.callable(wait_func):
         return wait_func
 
-    takes_call_state = _func_takes_call_state(wait_func)
+    takes_call_state = _utils._func_takes_call_state(wait_func)
     if takes_call_state:
         return wait_func
 

--- a/tenacity/wait.py
+++ b/tenacity/wait.py
@@ -39,7 +39,7 @@ def _make_wait_call_state(previous_attempt_number, delay_since_first_attempt,
         raise TypeError('wait func missing parameters: ' + missing_str)
 
     from tenacity import RetryCallState
-    call_state = RetryCallState(None, (), {})
+    call_state = RetryCallState(None, None, (), {})
     call_state.attempt_number = previous_attempt_number
     call_state.outcome_timestamp = (
         call_state.start_time + delay_since_first_attempt)


### PR DESCRIPTION
This PR continues work started in #122 adding support for call_state in `before_sleep` and opening a possibility to improve logging even further as requested in comments in #77.

Before this is getting merged I'd like to update the documentation and fix `before_sleep_log` function to log non-exceptions as well.