### PR TITLE
Add retry_if_exception_message

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -47,6 +47,8 @@ from .retry import retry_if_not_result  # noqa
 from .retry import retry_if_result  # noqa
 from .retry import retry_never  # noqa
 from .retry import retry_unless_exception_type  # noqa
+from .retry import retry_if_exception_message  # noqa
+from .retry import retry_if_not_exception_message  # noqa
 
 # Import all nap strategies for easier usage.
 from .nap import sleep  # noqa


### PR DESCRIPTION
From issue #125.

Add retry classes for exception messages.

I'm very open to name suggestions. Specifically wondering if `retry_if_not_exception_message` or `retry_until_exception_message` is best.

`retry_if_exception_message` and it's complement act different out of necessity. The normal class can end if there is no exception whereas it's inverse needs to retry if there is no exception message.

It's worth noting in my branch unit tests are intermittently failing on [wait class backwards incompatibility](https://travis-ci.org/Brian-Williams/tenacity/jobs/405236070#L470). I don't believe this is caused by any of my changes, but it's worth noting.