### PR TITLE
Fix six.wraps having a problem with __name__ attr on Py2

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -268,7 +268,7 @@ class BaseRetrying(object):
 
         :param f: A function to wraps for retrying.
         """
-        @six.wraps(f)
+        @_utils.wraps(f)
         def wrapped_f(*args, **kw):
             return self.call(f, *args, **kw)
 

--- a/tenacity/tests/test_tenacity.py
+++ b/tenacity/tests/test_tenacity.py
@@ -866,6 +866,20 @@ class TestDecoratorWrapper(unittest.TestCase):
         self.assertTrue(_retryable_default(NoCustomErrorAfterCount(5)))
         self.assertTrue(_retryable_default_f(NoCustomErrorAfterCount(5)))
 
+    def test_retry_function_object(self):
+        """Test that six.wraps doesn't cause problems with callable objects.
+
+        It raises an error upon trying to wrap it in Py2, because __name__
+        attribute is missing. It's fixed in Py3 but was never backported.
+        """
+        class Hello(object):
+            def __call__(self):
+                return "Hello"
+        retrying = Retrying(wait=tenacity.wait_fixed(0.01),
+                            stop=tenacity.stop_after_attempt(3))
+        h = retrying.wraps(Hello())
+        self.assertEqual(h(), "Hello")
+
 
 class TestBeforeAfterAttempts(unittest.TestCase):
     _attempt_number = 0


### PR DESCRIPTION
The fix is rather trivial. Without it the new test fails with the following error:
```
    def update_wrapper(wrapper,
                       wrapped,
                       assigned = WRAPPER_ASSIGNMENTS,
                       updated = WRAPPER_UPDATES):
        """Update a wrapper function to look like the wrapped function
    
           wrapper is the function to be updated
           wrapped is the original function
           assigned is a tuple naming the attributes assigned directly
           from the wrapped function to the wrapper function (defaults to
           functools.WRAPPER_ASSIGNMENTS)
           updated is a tuple naming the attributes of the wrapper that
           are updated with the corresponding attribute from the wrapped
           function (defaults to functools.WRAPPER_UPDATES)
        """
        for attr in assigned:
>           setattr(wrapper, attr, getattr(wrapped, attr))
E           AttributeError: 'Hello' object has no attribute '__name__'
```
This was fixed in Py3 (https://bugs.python.org/issue3445), but was never backported to Py2 or six.
