### PR TITLE
python2 bdist_rpm build fix #88

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import shutil
+import sys
+
 import setuptools
+
+
+# Useful for very coarse version differentiation.
+PY2 = sys.version_info[0] == 2
+# files that can only be compiled with Python 3
+PY3_FILES_PATH = ['tenacity/_asyncio.py', 'tenacity/tests/test_asyncio.py']
+if PY2:
+    for fn in PY3_FILES_PATH:
+        print(os.listdir(os.getcwd()))
+        if os.path.isfile(fn):
+            shutil.move(fn, '%s.null' % fn)
 
 setuptools.setup(
     setup_requires=['pbr'],


### PR DESCRIPTION
to test on centos build with python2 and python3

e.g.
python2:
`python setup.py bdist_rpm --python /usr/bin/python2`
python3:
`python setup.py bdist_rpm --python /usr/bin/python3`