### PR TITLE
stop, retry: add compatibility wrappers for __call__ methods

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -315,17 +315,17 @@ class BaseRetrying(object):
 
         is_explicit_retry = retry_state.outcome.failed \
             and isinstance(retry_state.outcome.exception(), TryAgain)
-        if not (is_explicit_retry or self.retry(retry_state)):
+        if not (is_explicit_retry or self.retry(retry_state=retry_state)):
             return fut.result()
 
         if self.after is not None:
-            self.after(retry_state)
+            self.after(retry_state=retry_state)
 
         self.statistics['delay_since_first_attempt'] = \
             retry_state.seconds_since_start
-        if self.stop(retry_state):
+        if self.stop(retry_state=retry_state):
             if self.retry_error_callback:
-                return self.retry_error_callback(retry_state)
+                return self.retry_error_callback(retry_state=retry_state)
             retry_exc = self.retry_error_cls(fut)
             if self.reraise:
                 raise retry_exc.reraise()

--- a/tenacity/retry.py
+++ b/tenacity/retry.py
@@ -63,6 +63,7 @@ class retry_if_exception(retry_base):
     def __init__(self, predicate):
         self.predicate = predicate
 
+    @_compat.retry_dunder_call_accept_old_params
     def __call__(self, retry_state):
         if retry_state.outcome.failed:
             return self.predicate(retry_state.outcome.exception())
@@ -85,6 +86,7 @@ class retry_unless_exception_type(retry_if_exception):
         super(retry_unless_exception_type, self).__init__(
             lambda e: not isinstance(e, exception_types))
 
+    @_compat.retry_dunder_call_accept_old_params
     def __call__(self, retry_state):
         # always retry if no exception was raised
         if not retry_state.outcome.failed:
@@ -98,6 +100,7 @@ class retry_if_result(retry_base):
     def __init__(self, predicate):
         self.predicate = predicate
 
+    @_compat.retry_dunder_call_accept_old_params
     def __call__(self, retry_state):
         if not retry_state.outcome.failed:
             return self.predicate(retry_state.outcome.result())
@@ -109,6 +112,7 @@ class retry_if_not_result(retry_base):
     def __init__(self, predicate):
         self.predicate = predicate
 
+    @_compat.retry_dunder_call_accept_old_params
     def __call__(self, retry_state):
         if not retry_state.outcome.failed:
             return not self.predicate(retry_state.outcome.result())
@@ -152,6 +156,7 @@ class retry_if_not_exception_message(retry_if_exception_message):
         self.predicate = lambda *args_, **kwargs_: not if_predicate(
             *args_, **kwargs_)
 
+    @_compat.retry_dunder_call_accept_old_params
     def __call__(self, retry_state):
         if not retry_state.outcome.failed:
             return True
@@ -165,6 +170,7 @@ class retry_any(retry_base):
         self.retries = tuple(_compat.retry_func_accept_retry_state(r)
                              for r in retries)
 
+    @_compat.retry_dunder_call_accept_old_params
     def __call__(self, retry_state):
         return any(r(retry_state) for r in self.retries)
 
@@ -176,5 +182,6 @@ class retry_all(retry_base):
         self.retries = tuple(_compat.retry_func_accept_retry_state(r)
                              for r in retries)
 
+    @_compat.retry_dunder_call_accept_old_params
     def __call__(self, retry_state):
         return all(r(retry_state) for r in self.retries)

--- a/tenacity/stop.py
+++ b/tenacity/stop.py
@@ -42,6 +42,7 @@ class stop_any(stop_base):
         self.stops = tuple(_compat.stop_func_accept_retry_state(stop_func)
                            for stop_func in stops)
 
+    @_compat.stop_dunder_call_accept_old_params
     def __call__(self, retry_state):
         return any(x(retry_state) for x in self.stops)
 
@@ -53,6 +54,7 @@ class stop_all(stop_base):
         self.stops = tuple(_compat.stop_func_accept_retry_state(stop_func)
                            for stop_func in stops)
 
+    @_compat.stop_dunder_call_accept_old_params
     def __call__(self, retry_state):
         return all(x(retry_state) for x in self.stops)
 
@@ -60,6 +62,7 @@ class stop_all(stop_base):
 class _stop_never(stop_base):
     """Never stop."""
 
+    @_compat.stop_dunder_call_accept_old_params
     def __call__(self, retry_state):
         return False
 
@@ -73,6 +76,7 @@ class stop_when_event_set(stop_base):
     def __init__(self, event):
         self.event = event
 
+    @_compat.stop_dunder_call_accept_old_params
     def __call__(self, retry_state):
         return self.event.is_set()
 
@@ -83,6 +87,7 @@ class stop_after_attempt(stop_base):
     def __init__(self, max_attempt_number):
         self.max_attempt_number = max_attempt_number
 
+    @_compat.stop_dunder_call_accept_old_params
     def __call__(self, retry_state):
         return retry_state.attempt_number >= self.max_attempt_number
 
@@ -93,5 +98,6 @@ class stop_after_delay(stop_base):
     def __init__(self, max_delay):
         self.max_delay = max_delay
 
+    @_compat.stop_dunder_call_accept_old_params
     def __call__(self, retry_state):
         return retry_state.seconds_since_start >= self.max_delay

--- a/tenacity/tests/test_tenacity.py
+++ b/tenacity/tests/test_tenacity.py
@@ -116,6 +116,23 @@ class TestStopConditions(unittest.TestCase):
         with reports_deprecation_warning():
             self.assertTrue(r.stop(make_retry_state(101, 101)))
 
+    def test_retry_child_class_with_override_backward_compat(self):
+
+        class MyStop(tenacity.stop_after_attempt):
+            def __init__(self):
+                super(MyStop, self).__init__(1)
+
+            def __call__(self, attempt_number, seconds_since_start):
+                return super(MyStop, self).__call__(
+                    attempt_number, seconds_since_start)
+        retrying = Retrying(wait=tenacity.wait_fixed(0.01),
+                            stop=MyStop())
+
+        def failing():
+            raise NotImplementedError()
+        with pytest.raises(RetryError):
+            retrying.call(failing)
+
     def test_stop_func_with_retry_state(self):
         def stop_func(retry_state):
             rs = retry_state
@@ -962,6 +979,25 @@ class TestDecoratorWrapper(unittest.TestCase):
                             stop=tenacity.stop_after_attempt(3))
         h = retrying.wraps(Hello())
         self.assertEqual(h(), "Hello")
+
+    def test_retry_child_class_with_override_backward_compat(self):
+        def always_true(_):
+            return True
+
+        class MyRetry(tenacity.retry_if_exception):
+            def __init__(self):
+                super(MyRetry, self).__init__(always_true)
+
+            def __call__(self, attempt):
+                return super(MyRetry, self).__call__(attempt)
+        retrying = Retrying(wait=tenacity.wait_fixed(0.01),
+                            stop=tenacity.stop_after_attempt(1),
+                            retry=MyRetry())
+
+        def failing():
+            raise NotImplementedError()
+        with pytest.raises(RetryError):
+            retrying.call(failing)
 
 
 class TestBeforeAfterAttempts(unittest.TestCase):


### PR DESCRIPTION
They can be called side-stepping the "primary" backward compatibility shim
provided by BaseRetrying class, for example when an inherited class uses an old
signature in a "return super().__call__"

This should fix #139 