### PR TITLE
Add reno (changelog system)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,15 @@ matrix:
       dist: xenial
       sudo: required
 
-install: pip install tox tox-travis
+install:
+  - |
+    # Force unshallow and checkout the current branch
+    # https://docs.openstack.org/reno/latest/user/usage.html#within-travis-ci
+    git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+    git fetch --unshallow --tags
+    git symbolic-ref --short HEAD || git checkout -b ${TRAVIS_BRANCH}-test $TRAVIS_BRANCH
+    # Ref: https://stackoverflow.com/questions/32580821/how-can-i-customize-override-the-git-clone-step-in-travis-ci
+  - pip install tox tox-travis
 
 script: tox
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -1,0 +1,4 @@
+Changelog
+=========
+
+.. release-notes::

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -24,6 +24,7 @@ project = "Tenacity"
 extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.autodoc',
+    'reno.sphinxext',
 ]
 
 # -- Options for sphinx.ext.doctest  -----------------------------------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -39,6 +39,14 @@ occurs until a value is returned.
 
    Awesome sauce!
 
+
+.. toctree::
+    :hidden:
+    :maxdepth: 2
+
+    changelog
+
+
 Features
 --------
 
@@ -600,6 +608,21 @@ Contribute
    **master** branch (or branch off of it).
 #. Write a test which shows that the bug was fixed or that the feature works as
    expected.
+#. Add a `changelog <#Changelogs>`_
 #. Make the docs better (or more detailed, or more easier to read, or ...)
 
 .. _`the repository`: https://github.com/jd/tenacity
+
+Changelogs
+~~~~~~~~~~
+
+`reno`_ is used for managing changelogs. Take a look at their usage docs.
+
+The doc generation will automatically compile the changelogs. You just need to add them.
+
+.. code-block:: sh
+
+    # Opens a template file in an editor
+    tox -e reno -- new some-slug-for-my-change --edit
+
+.. _`reno`: https://docs.openstack.org/reno/latest/user/usage.html

--- a/releasenotes/notes/add-reno-d1ab5710f272650a.yaml
+++ b/releasenotes/notes/add-reno-d1ab5710f272650a.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Add reno (changelog system)

--- a/reno.yaml
+++ b/reno.yaml
@@ -1,0 +1,2 @@
+---
+unreleased_version_title: Unreleased

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     pytest
     sphinx
     tornado>=4.5
+    {[testenv:reno]deps}
 commands =
     py{27,py}: pytest --ignore='tenacity/tests/test_asyncio.py' '{posargs}'
     py3{5,6}: pytest '{posargs}'
@@ -31,6 +32,11 @@ deps = flake8
        flake8-rst-docstrings
        flake8-logging-format
 commands = flake8
+
+[testenv:reno]
+basepython = python3
+deps = reno
+commands = reno {posargs}
 
 [flake8]
 exclude = .tox,.eggs


### PR DESCRIPTION
Addresses #83 

I defer to you on particulars on configuration, formatting, process, etc. This is to just get the system up and running to start.

I'm not sure how to configure the Travis parts. reno [recommends tweaking the setup](https://docs.openstack.org/reno/latest/user/usage.html#within-travis-ci) for the build, but I don't think that's necessary for every tox-env that'll run. Just whatever is the env's docs will actually be uploaded.

![screenshot from 2018-10-26 22-49-34](https://user-images.githubusercontent.com/29210237/47600146-75760200-d971-11e8-9c15-26be1853e74b.png)
![screenshot from 2018-10-26 22-49-40](https://user-images.githubusercontent.com/29210237/47600147-773fc580-d971-11e8-92da-62d3d8764273.png)
