### PR TITLE
Tweak pytest - only show DeprecationWarnings once

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,3 +29,8 @@ packages = tenacity
 
 [wheel]
 universal = 1
+
+[tool:pytest]
+filterwarnings =
+    # Show any DeprecationWarnings once
+    once::DeprecationWarning


### PR DESCRIPTION
They still need to be fixed, but if they spam too much, Travis will
abort the build. An Ode to Software Systems!

Before:
```
$ ~/c/tenacity> tox -e py27 > log.txt
$ ~/c/tenacity> ll log.txt
-rw-r--r-- 1 me me 12M Nov  2 11:37 log.txt
```

After:
```
$ ~/c/tenacity> tox -e py27 > log.txt
$ ~/c/tenacity> ll log.txt
-rw-r--r-- 1 me me 4.5K Nov  2 11:37 log.txt
```
