### PR TITLE
Stop: Add stop_after_exception_count.

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -30,6 +30,7 @@ except ImportError:
 import sys
 import threading
 from concurrent import futures
+from collections import Counter
 
 import six
 
@@ -56,6 +57,7 @@ from .nap import sleep_using_event  # noqa
 # Import all built-in stop strategies for easier usage.
 from .stop import stop_after_attempt  # noqa
 from .stop import stop_after_delay  # noqa
+from .stop import stop_after_exception_count  # noqa
 from .stop import stop_all  # noqa
 from .stop import stop_any  # noqa
 from .stop import stop_never  # noqa
@@ -412,6 +414,8 @@ class RetryCallState(object):
 
         #: The number of the current attempt
         self.attempt_number = 1
+        #: Tracks exceptions raised by the method, by type
+        self.exception_counts = Counter()
         #: Last outcome (result or exception) produced by the function
         self.outcome = None
         #: Timestamp of the last outcome
@@ -443,6 +447,7 @@ class RetryCallState(object):
         ts = _utils.now()
         fut = Future(self.attempt_number)
         _utils.capture(fut, exc_info)
+        self.exception_counts[type(fut.exception())] += 1
         self.outcome, self.outcome_timestamp = fut, ts
 
 

--- a/tenacity/stop.py
+++ b/tenacity/stop.py
@@ -101,3 +101,15 @@ class stop_after_delay(stop_base):
     @_compat.stop_dunder_call_accept_old_params
     def __call__(self, retry_state):
         return retry_state.seconds_since_start >= self.max_delay
+
+
+class stop_after_exception_count(stop_base):
+    """Stop after an excpetion occured >= max_attemps."""
+
+    def __init__(self, exception_type, max_attempts):
+        self.exception_type = exception_type
+        self.max_attempts = max_attempts
+
+    @_compat.stop_dunder_call_accept_old_params
+    def __call__(self, retry_state):
+        return retry_state.exception_counts[self.exception_type] >= self.max_attempts


### PR DESCRIPTION
Add the ability to stop after a specific exception occurred X times.

Count occurrences of each exception in the RetryCallState, and check it in the stop predicate.