### PR TITLE
Ensure that the _asyncio.py module can be compiled, even on Python 2

### DIFF
--- a/tenacity/_asyncio.py
+++ b/tenacity/_asyncio.py
@@ -16,7 +16,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
+try:
+    import asyncio
+except ImportError:
+    asyncio = None
+
 import sys
 
 from tenacity import BaseRetrying
@@ -25,31 +29,32 @@ from tenacity import DoSleep
 from tenacity import RetryCallState
 
 
-class AsyncRetrying(BaseRetrying):
+if asyncio:
+    class AsyncRetrying(BaseRetrying):
 
-    def __init__(self,
-                 sleep=asyncio.sleep,
-                 **kwargs):
-        super(AsyncRetrying, self).__init__(**kwargs)
-        self.sleep = sleep
+        def __init__(self,
+                     sleep=asyncio.sleep,
+                     **kwargs):
+            super(AsyncRetrying, self).__init__(**kwargs)
+            self.sleep = sleep
 
-    @asyncio.coroutine
-    def call(self, fn, *args, **kwargs):
-        self.begin(fn)
+        @asyncio.coroutine
+        def call(self, fn, *args, **kwargs):
+            self.begin(fn)
 
-        retry_state = RetryCallState(
-            retry_object=self, fn=fn, args=args, kwargs=kwargs)
-        while True:
-            do = self.iter(retry_state=retry_state)
-            if isinstance(do, DoAttempt):
-                try:
-                    result = yield from fn(*args, **kwargs)
-                except BaseException:
-                    retry_state.set_exception(sys.exc_info())
+            retry_state = RetryCallState(
+                retry_object=self, fn=fn, args=args, kwargs=kwargs)
+            while True:
+                do = self.iter(retry_state=retry_state)
+                if isinstance(do, DoAttempt):
+                    try:
+                        result = yield from fn(*args, **kwargs)
+                    except BaseException:
+                        retry_state.set_exception(sys.exc_info())
+                    else:
+                        retry_state.set_result(result)
+                elif isinstance(do, DoSleep):
+                    retry_state.prepare_for_next_attempt()
+                    yield from self.sleep(do)
                 else:
-                    retry_state.set_result(result)
-            elif isinstance(do, DoSleep):
-                retry_state.prepare_for_next_attempt()
-                yield from self.sleep(do)
-            else:
-                return do
+                    return do


### PR DESCRIPTION
Use the same pattern of conditional importing of _compat.py as used in
__init__.py to ensure that _compat.py can be compiled on Python 2.

Fixes jd/tenacity#88