### PR TITLE
Support async keyword properly

### DIFF
--- a/tenacity/_asyncio.py
+++ b/tenacity/_asyncio.py
@@ -38,6 +38,12 @@ if asyncio:
             super(AsyncRetrying, self).__init__(**kwargs)
             self.sleep = sleep
 
+        def wraps(self, fn):
+            fn = super().wraps(fn)
+            # Ensure wrapper is recognized as a coroutine function.
+            fn._is_coroutine = asyncio.coroutines._is_coroutine
+            return fn
+
         @asyncio.coroutine
         def call(self, fn, *args, **kwargs):
             self.begin(fn)

--- a/tenacity/tests/test_asyncio.py
+++ b/tenacity/tests/test_asyncio.py
@@ -36,9 +36,8 @@ def asynctest(callable_):
 
 
 @retry
-@asyncio.coroutine
-def _retryable_coroutine(thing):
-    yield from asyncio.sleep(0.00001)
+async def _retryable_coroutine(thing):
+    await asyncio.sleep(0.00001)
     return thing.go()
 
 


### PR DESCRIPTION
This is easier since tenacity dropped support for 3.4.

Should fix #181 