### PR TITLE
Use PEP 492 async/await syntax

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -18,9 +18,9 @@
 # limitations under the License.
 
 try:
-    import asyncio
+    from inspect import iscoroutinefunction
 except ImportError:
-    asyncio = None
+    iscoroutinefunction = None
 
 try:
     import tornado
@@ -96,7 +96,7 @@ def retry(*dargs, **dkw):
         return retry()(dargs[0])
     else:
         def wrap(f):
-            if asyncio and asyncio.iscoroutinefunction(f):
+            if iscoroutinefunction is not None and iscoroutinefunction(f):
                 r = AsyncRetrying(*dargs, **dkw)
             elif tornado and hasattr(tornado.gen, 'is_coroutine_function') \
                     and tornado.gen.is_coroutine_function(f):
@@ -479,7 +479,7 @@ class RetryCallState(object):
         self.outcome, self.outcome_timestamp = fut, ts
 
 
-if asyncio:
+if iscoroutinefunction:
     from tenacity._asyncio import AsyncRetrying
 
 if tornado:

--- a/tenacity/_asyncio.py
+++ b/tenacity/_asyncio.py
@@ -16,10 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import asyncio
-except ImportError:
-    asyncio = None
+from asyncio import sleep
 
 import sys
 
@@ -28,39 +25,30 @@ from tenacity import DoAttempt
 from tenacity import DoSleep
 from tenacity import RetryCallState
 
+class AsyncRetrying(BaseRetrying):
 
-if asyncio:
-    class AsyncRetrying(BaseRetrying):
+    def __init__(self,
+                    sleep=sleep,
+                    **kwargs):
+        super(AsyncRetrying, self).__init__(**kwargs)
+        self.sleep = sleep
 
-        def __init__(self,
-                     sleep=asyncio.sleep,
-                     **kwargs):
-            super(AsyncRetrying, self).__init__(**kwargs)
-            self.sleep = sleep
+    async def call(self, fn, *args, **kwargs):
+        self.begin(fn)
 
-        def wraps(self, fn):
-            fn = super().wraps(fn)
-            # Ensure wrapper is recognized as a coroutine function.
-            fn._is_coroutine = asyncio.coroutines._is_coroutine
-            return fn
-
-        @asyncio.coroutine
-        def call(self, fn, *args, **kwargs):
-            self.begin(fn)
-
-            retry_state = RetryCallState(
-                retry_object=self, fn=fn, args=args, kwargs=kwargs)
-            while True:
-                do = self.iter(retry_state=retry_state)
-                if isinstance(do, DoAttempt):
-                    try:
-                        result = yield from fn(*args, **kwargs)
-                    except BaseException:
-                        retry_state.set_exception(sys.exc_info())
-                    else:
-                        retry_state.set_result(result)
-                elif isinstance(do, DoSleep):
-                    retry_state.prepare_for_next_attempt()
-                    yield from self.sleep(do)
+        retry_state = RetryCallState(
+            retry_object=self, fn=fn, args=args, kwargs=kwargs)
+        while True:
+            do = self.iter(retry_state=retry_state)
+            if isinstance(do, DoAttempt):
+                try:
+                    result = await fn(*args, **kwargs)
+                except BaseException:
+                    retry_state.set_exception(sys.exc_info())
                 else:
-                    return do
+                    retry_state.set_result(result)
+            elif isinstance(do, DoSleep):
+                retry_state.prepare_for_next_attempt()
+                await self.sleep(do)
+            else:
+                return do

--- a/tenacity/_asyncio.py
+++ b/tenacity/_asyncio.py
@@ -16,20 +16,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from asyncio import sleep
-
 import sys
+from asyncio import sleep
 
 from tenacity import BaseRetrying
 from tenacity import DoAttempt
 from tenacity import DoSleep
 from tenacity import RetryCallState
 
+
 class AsyncRetrying(BaseRetrying):
 
     def __init__(self,
-                    sleep=sleep,
-                    **kwargs):
+                 sleep=sleep,
+                 **kwargs):
         super(AsyncRetrying, self).__init__(**kwargs)
         self.sleep = sleep
 

--- a/tenacity/tests/test_asyncio.py
+++ b/tenacity/tests/test_asyncio.py
@@ -25,8 +25,6 @@ from tenacity.tests.test_tenacity import NoIOErrorAfterCount
 
 
 def asynctest(callable_):
-    callable_ = asyncio.coroutine(callable_)
-
     @six.wraps(callable_)
     def wrapper(*a, **kw):
         loop = asyncio.get_event_loop()
@@ -42,27 +40,23 @@ async def _retryable_coroutine(thing):
 
 
 @retry(stop=stop_after_attempt(2))
-@asyncio.coroutine
-def _retryable_coroutine_with_2_attempts(thing):
-    yield from asyncio.sleep(0.00001)
+async def _retryable_coroutine_with_2_attempts(thing):
+    await asyncio.sleep(0.00001)
     thing.go()
 
 
 class TestAsync(unittest.TestCase):
     @asynctest
-    def test_retry(self):
-        assert asyncio.iscoroutinefunction(_retryable_coroutine)
+    async def test_retry(self):
         thing = NoIOErrorAfterCount(5)
-        yield from _retryable_coroutine(thing)
+        await _retryable_coroutine(thing)
         assert thing.counter == thing.count
 
     @asynctest
-    def test_stop_after_attempt(self):
-        assert asyncio.iscoroutinefunction(
-            _retryable_coroutine_with_2_attempts)
+    async def test_stop_after_attempt(self):
         thing = NoIOErrorAfterCount(2)
         try:
-            yield from _retryable_coroutine_with_2_attempts(thing)
+            await _retryable_coroutine_with_2_attempts(thing)
         except RetryError:
             assert thing.counter == 2
 
@@ -70,7 +64,7 @@ class TestAsync(unittest.TestCase):
         repr(tasyncio.AsyncRetrying())
 
     @asynctest
-    def test_attempt_number_is_correct_for_interleaved_coroutines(self):
+    async def test_attempt_number_is_correct_for_interleaved_coroutines(self):
 
         attempts = []
 
@@ -79,11 +73,10 @@ class TestAsync(unittest.TestCase):
 
         thing1 = NoIOErrorAfterCount(3)
         thing2 = NoIOErrorAfterCount(3)
-        future1 = asyncio.ensure_future(
-            _retryable_coroutine.retry_with(after=after)(thing1))
-        future2 = asyncio.ensure_future(
+
+        await asyncio.gather(
+            _retryable_coroutine.retry_with(after=after)(thing1),
             _retryable_coroutine.retry_with(after=after)(thing2))
-        yield from asyncio.gather(future1, future2)
 
         # There's no waiting on retry, only a wait in the coroutine, so the
         # executions should be interleaved.

--- a/tenacity/tests/test_asyncio.py
+++ b/tenacity/tests/test_asyncio.py
@@ -76,18 +76,18 @@ class TestAsync(unittest.TestCase):
 
         await asyncio.gather(
             _retryable_coroutine.retry_with(after=after)(thing1),
-            _retryable_coroutine.retry_with(after=after)(thing2))
+            _retryable_coroutine.retry_with(after=after)(thing2))        
 
         # There's no waiting on retry, only a wait in the coroutine, so the
         # executions should be interleaved.
-        thing1_attempts = attempts[::2]
-        things1, attempt_nos1 = zip(*thing1_attempts)
-        assert all(thing is thing1 for thing in things1)
+        even_thing_attempts = attempts[::2]
+        things, attempt_nos1 = zip(*even_thing_attempts)
+        assert len(set(things)) == 1
         assert list(attempt_nos1) == [1, 2, 3]
 
-        thing2_attempts = attempts[1::2]
-        things2, attempt_nos2 = zip(*thing2_attempts)
-        assert all(thing is thing2 for thing in things2)
+        odd_thing_attempts = attempts[1::2]
+        things, attempt_nos2 = zip(*odd_thing_attempts)
+        assert len(set(things)) == 1
         assert list(attempt_nos2) == [1, 2, 3]
 
 

--- a/tenacity/tests/test_asyncio.py
+++ b/tenacity/tests/test_asyncio.py
@@ -76,7 +76,7 @@ class TestAsync(unittest.TestCase):
 
         await asyncio.gather(
             _retryable_coroutine.retry_with(after=after)(thing1),
-            _retryable_coroutine.retry_with(after=after)(thing2))        
+            _retryable_coroutine.retry_with(after=after)(thing2))
 
         # There's no waiting on retry, only a wait in the coroutine, so the
         # executions should be interleaved.


### PR DESCRIPTION
Hi, I just saw there was a larger PR with most of these changes.

This is just isolated modern async/await syntax.

I removed some code. This code doesn't bother with applying magic flags to the wrapped function to make it look like it is a coroutine. In my view, why bother with that check? The user should know what he is doing, so it should just work. 

I also tried to minimize asyncio dependancy to just tests and importing asyncio.sleep.