### PR TITLE
Add minimal type definitions for @retry decorator

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,11 @@ install_requires =
     six>=1.9.0
     futures>=3.0;python_version=='2.7'
     monotonic>=0.6;python_version=='2.7'
+    typing>=3.7.4.1;python_version=='2.7'
 packages = tenacity
+
+[options.package_data]
+tenacity = py.typed
 
 [options.extras_require]
 doc =

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -29,6 +29,7 @@ except ImportError:
 
 import sys
 import threading
+import typing as t
 from concurrent import futures
 
 import six
@@ -85,7 +86,24 @@ from .before_sleep import before_sleep_log  # noqa
 from .before_sleep import before_sleep_nothing  # noqa
 
 
-def retry(*dargs, **dkw):
+WrappedFn = t.TypeVar("WrappedFn", bound=t.Callable)
+
+
+@t.overload
+def retry(fn):
+    # type: (WrappedFn) -> WrappedFn
+    """Type signature for @retry as a raw decorator."""
+    pass
+
+
+@t.overload
+def retry(*dargs, **dkw):  # noqa
+    # type: (...) -> t.Callable[[WrappedFn], WrappedFn]
+    """Type signature for the @retry() decorator constructor."""
+    pass
+
+
+def retry(*dargs, **dkw):  # noqa
     """Wrap a function with a new `Retrying` object.
 
     :param dargs: positional arguments passed to Retrying object

--- a/tenacity/tests/test_tenacity.py
+++ b/tenacity/tests/test_tenacity.py
@@ -1395,9 +1395,12 @@ class TestRetryException(unittest.TestCase):
 
 class TestRetryTyping(unittest.TestCase):
 
-    @pytest.mark.skipif(sys.version_info < (3, 0), reason="typeguard not supported for python 2")
+    @pytest.mark.skipif(
+        sys.version_info < (3, 0),
+        reason="typeguard not supported for python 2"
+    )
     def test_retry_type_annotations(self):
-        """The register decorator should maintain types of decorated functions."""
+        """The decorator should maintain types of decorated functions."""
 
         # Just in case this is run with unit-test, return early for py2
         if sys.version_info < (3, 0):
@@ -1421,7 +1424,9 @@ class TestRetryTyping(unittest.TestCase):
         # These raise TypeError exceptions if they fail
         check_type("with_raw", with_raw, typing.Callable[[int], str])
         check_type("with_raw_result", with_raw_result, str)
-        check_type("with_constructor", with_constructor, typing.Callable[[int], str])
+        check_type(
+            "with_constructor", with_constructor, typing.Callable[[int], str]
+        )
         check_type("with_constructor_result", with_constructor_result, str)
 
 

--- a/tenacity/tests/test_tenacity.py
+++ b/tenacity/tests/test_tenacity.py
@@ -1401,7 +1401,6 @@ class TestRetryTyping(unittest.TestCase):
     )
     def test_retry_type_annotations(self):
         """The decorator should maintain types of decorated functions."""
-
         # Just in case this is run with unit-test, return early for py2
         if sys.version_info < (3, 0):
             return

--- a/tenacity/tests/test_tenacity.py
+++ b/tenacity/tests/test_tenacity.py
@@ -16,7 +16,7 @@
 import logging
 import sys
 import time
-import typing as t
+import typing
 import unittest
 import warnings
 from contextlib import contextmanager
@@ -1419,9 +1419,9 @@ class TestRetryTyping(unittest.TestCase):
         with_constructor_result = with_raw(1)
 
         # These raise TypeError exceptions if they fail
-        check_type("with_raw", with_raw, t.Callable[[int], str])
+        check_type("with_raw", with_raw, typing.Callable[[int], str])
         check_type("with_raw_result", with_raw_result, str)
-        check_type("with_constructor", with_constructor, t.Callable[[int], str])
+        check_type("with_constructor", with_constructor, typing.Callable[[int], str])
         check_type("with_constructor_result", with_constructor_result, str)
 
 

--- a/tenacity/tests/test_tenacity.py
+++ b/tenacity/tests/test_tenacity.py
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import sys
 import time
+import typing as t
 import unittest
 import warnings
 from contextlib import contextmanager
@@ -1389,6 +1391,38 @@ class TestRetryException(unittest.TestCase):
         pickled = pickle.dumps(expected)
         actual = pickle.loads(pickled)
         self.assertEqual(expected.last_attempt, actual.last_attempt)
+
+
+class TestRetryTyping(unittest.TestCase):
+
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="typeguard not supported for python 2")
+    def test_retry_type_annotations(self):
+        """The register decorator should maintain types of decorated functions."""
+
+        # Just in case this is run with unit-test, return early for py2
+        if sys.version_info < (3, 0):
+            return
+
+        # Function-level import because we can't install this for python 2.
+        from typeguard import check_type
+
+        def num_to_str(number):
+            # type: (int) -> str
+            return str(number)
+
+        # equivalent to a raw @retry decoration
+        with_raw = retry(num_to_str)
+        with_raw_result = with_raw(1)
+
+        # equivalent to a @retry(...) decoration
+        with_constructor = retry()(num_to_str)
+        with_constructor_result = with_raw(1)
+
+        # These raise TypeError exceptions if they fail
+        check_type("with_raw", with_raw, t.Callable[[int], str])
+        check_type("with_raw_result", with_raw_result, str)
+        check_type("with_constructor", with_constructor, t.Callable[[int], str])
+        check_type("with_constructor_result", with_constructor_result, str)
 
 
 @contextmanager

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ sitepackages = False
 deps =
     .[doc]
     pytest
+    typeguard;python_version>='3.0'
 commands =
     py{27,py}: pytest --ignore='tenacity/tests/test_asyncio.py' {posargs}
     py3{5,6,7,8}: pytest {posargs}


### PR DESCRIPTION
Hi!

We're considering retry libraries for some internal code on a well type annotated python3 codebase. Tenacity looks good, but an issue is the lack of type support, because wrapping a function in `@retry` causes its type to become degraded to `Any` (essentially untyped), losing the benefit of any type annotations on the decorated function.

This PR contains the minimal set of changes required to get the `@retry` decorator supporting typechecking properly: it defines two [overloads](https://docs.python.org/3/library/typing.html#typing.overload), one for the decorator being used without arguments and another for the decorator being used as a decorator constructor. In both cases, the type signature specifies that the resulting callable has the same signature as the wrapped function. 

It adds the `typing` backport as a requirement for python 2.7, and adds the empty `py.typed` file that [PEP 561](https://www.python.org/dev/peps/pep-0561/) specifies must be included in package data to signal to code that uses a library that the library contains type annotations.

I've done the type-annotations in code as comments, because I've found them much easier to keep up-to-date that way, but if you'd prefer, I could pull them out into a stub file instead.

There's more that could be done here with [protocols](https://docs.python.org/3/library/typing.html#typing.Protocol) to also provide hints on the various keyword arguments to `retry()`, but even without that, this change provides significant value for typed codebases.

I validated the signatures by doing a dev install of `tenacity` and running mypy on this example file:

```py
from tenacity import retry

@retry
def foo(a: str) -> str:
    return a + "foo"

@retry()
def foob(a: str) -> str:
    return a + "foob"

a = foo  # sig: def (a: builtins.str) -> builtins.str
b = foob  # sig: def (a: builtins.str) -> builtins.str

c = foo("foo")  # builtins.str
d = foob("foo")  # builtins.str

reveal_locals()
```

The `reveal_locals()` output is shown in comments next to the variables. Without this change, the revealed type of all variables is `Any`.

Thanks!