### PR TITLE
Do not pretend to contain type annotations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,9 +28,6 @@ install_requires =
     typing>=3.7.4.1;python_version=='2.7'
 packages = tenacity
 
-[options.package_data]
-tenacity = py.typed
-
 [options.extras_require]
 doc =
     reno


### PR DESCRIPTION
According to PEP 561, a file named py.typed in a package implies that the
code contains type hints. This is currently not the case, so remove it.

Resolves #230