### PR TITLE
issue-214/doc-fix

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -83,6 +83,10 @@ Basic Retry
 .. testsetup:: *
 
     import logging
+    #
+    # Note the following import is used for demonstration convenience only.
+    # Production code should always explicitly import the names it needs.
+    #
     from tenacity import *
 
     class MyException(Exception):


### PR DESCRIPTION
Add wording to caution the unwary reader against production use of `from tenacity import *`.

The contributor notes set the bar a little high for the casual repository browser, but this small
docfix should allow closing https://github.com/jd/tenacity/issues/214 with a relatively clear conscience.