### PR TITLE
Fix asyncio.iscoroutinefunction(f) check for decorated function

### DIFF
--- a/tenacity/_asyncio.py
+++ b/tenacity/_asyncio.py
@@ -15,7 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import asyncio
 import sys
 from asyncio import sleep
 
@@ -71,3 +71,9 @@ class AsyncRetrying(BaseRetrying):
                 await self.sleep(do)
             else:
                 return do
+
+    def wraps(self, fn):
+        fn = super().wraps(fn)
+        # Ensure wrapper is recognized as a coroutine function.
+        fn._is_coroutine = asyncio.coroutines._is_coroutine
+        return fn

--- a/tenacity/tests/test_asyncio.py
+++ b/tenacity/tests/test_asyncio.py
@@ -59,6 +59,10 @@ class TestAsync(unittest.TestCase):
         assert thing.counter == thing.count
 
     @asynctest
+    async def test_iscoroutinefunction(self):
+        assert asyncio.iscoroutinefunction(_retryable_coroutine)
+
+    @asynctest
     async def test_retry_using_async_retying(self):
         thing = NoIOErrorAfterCount(5)
         retrying = AsyncRetrying()


### PR DESCRIPTION
It was fixed [here](https://github.com/adjust/tenacity/commit/3bae79e71519ed1a34cea53dcf98903ef02eb6c7), but the fix was removed [here](https://github.com/adjust/tenacity/commit/66de0110844a742b820ab6c1f29edb19ed2e5908) (I think accidentally)

Fixes: https://github.com/jd/tenacity/issues/224