### PR TITLE
Fix iscoroutinefunction check (for both inspect & asyncio)

### DIFF
--- a/tenacity/_asyncio.py
+++ b/tenacity/_asyncio.py
@@ -74,10 +74,10 @@ class AsyncRetrying(BaseRetrying):
     def wraps(self, fn):
         fn = super().wraps(fn)
         # Ensure wrapper is recognized as a coroutine function.
-        
+
         async def async_wrapped(*args, **kwargs):
             return await fn(*args, **kwargs)
-        
+
         # Preserve attributes
         async_wrapped.retry = fn.retry
         async_wrapped.retry_with = fn.retry_with

--- a/tenacity/_asyncio.py
+++ b/tenacity/_asyncio.py
@@ -15,7 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import asyncio
 import sys
 from asyncio import sleep
 
@@ -75,5 +74,6 @@ class AsyncRetrying(BaseRetrying):
     def wraps(self, fn):
         fn = super().wraps(fn)
         # Ensure wrapper is recognized as a coroutine function.
-        fn._is_coroutine = asyncio.coroutines._is_coroutine
-        return fn
+        async def async_wrapped(*args, **kwargs):
+            return await fn(*args, **kwargs)
+        return async_wrapped

--- a/tenacity/_asyncio.py
+++ b/tenacity/_asyncio.py
@@ -74,6 +74,12 @@ class AsyncRetrying(BaseRetrying):
     def wraps(self, fn):
         fn = super().wraps(fn)
         # Ensure wrapper is recognized as a coroutine function.
+        
         async def async_wrapped(*args, **kwargs):
             return await fn(*args, **kwargs)
+        
+        # Preserve attributes
+        async_wrapped.retry = fn.retry
+        async_wrapped.retry_with = fn.retry_with
+
         return async_wrapped

--- a/tenacity/tests/test_asyncio.py
+++ b/tenacity/tests/test_asyncio.py
@@ -81,6 +81,10 @@ class TestAsync(unittest.TestCase):
 
     def test_repr(self):
         repr(tasyncio.AsyncRetrying())
+    
+    def test_retry_attributes(self):
+        assert hasattr(_retryable_coroutine, 'retry')
+        assert hasattr(_retryable_coroutine, 'retry_with')
 
     @asynctest
     async def test_attempt_number_is_correct_for_interleaved_coroutines(self):

--- a/tenacity/tests/test_asyncio.py
+++ b/tenacity/tests/test_asyncio.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import asyncio
+import inspect
 import unittest
 
 import six
@@ -61,6 +62,7 @@ class TestAsync(unittest.TestCase):
     @asynctest
     async def test_iscoroutinefunction(self):
         assert asyncio.iscoroutinefunction(_retryable_coroutine)
+        assert inspect.iscoroutinefunction(_retryable_coroutine)
 
     @asynctest
     async def test_retry_using_async_retying(self):

--- a/tenacity/tests/test_asyncio.py
+++ b/tenacity/tests/test_asyncio.py
@@ -81,7 +81,7 @@ class TestAsync(unittest.TestCase):
 
     def test_repr(self):
         repr(tasyncio.AsyncRetrying())
-    
+
     def test_retry_attributes(self):
         assert hasattr(_retryable_coroutine, 'retry')
         assert hasattr(_retryable_coroutine, 'retry_with')


### PR DESCRIPTION
#263 did not fully solve #224.

## current behavior

```bash
python -m pip install git+https://github.com/jd/tenacity.git@be9bccbb731d28ab0bcd8a4ee5acae70988bf593
```

```python
from inspect import iscoroutinefunction as inspect_iscoroutinefunction
from asyncio import iscoroutinefunction as asyncio_iscoroutinefunction

from tenacity import retry


async def a():
    pass

print(inspect_iscoroutinefunction(a), asyncio_iscoroutinefunction(a))

b = retry(a)

print(inspect_iscoroutinefunction(b), asyncio_iscoroutinefunction(b))
```

```bash
True True
False True
```

## How to solve

https://github.com/jd/tenacity/blob/be9bccbb731d28ab0bcd8a4ee5acae70988bf593/tenacity/_asyncio.py#L78

The reason that it passes `asyncio.iscoroutinefunction`  is:

> https://docs.python.org/3/library/asyncio-task.html#asyncio.iscoroutinefunction

> asyncio.iscoroutinefunction(func)
> Return True if func is a coroutine function.
> This method is different from inspect.iscoroutinefunction() because it returns True for generator-based coroutine functions decorated with @coroutine.

But it can not pass `inspect.iscoroutinefunction` since the returned `fn` is not an `async def` function.

Through explicitly defining an `async` function (wrapper) in https://github.com/jd/tenacity/blob/be9bccbb731d28ab0bcd8a4ee5acae70988bf593/tenacity/_asyncio.py#L75


one can make it pass both `inspect.iscoroutinefunction` and `asyncio.iscoroutinefunction`.