### PR TITLE
Add call method to BaseRetying

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -404,6 +404,12 @@ class BaseRetrying(object):
     def __call__(self, *args, **kwargs):
         pass
 
+    def call(self, *args, **kwargs):
+        """Use ``__call__`` instead because this method is deprecated."""
+        warnings.warn("'call()' method is deprecated. " +
+                      "Use '__call__()' instead", DeprecationWarning)
+        return self.__call__(*args, **kwargs)
+
 
 class Retrying(BaseRetrying):
     """Retrying controller."""
@@ -427,12 +433,6 @@ class Retrying(BaseRetrying):
                 self.sleep(do)
             else:
                 return do
-
-    def call(self, *args, **kwargs):
-        """Use ``__call__`` instead because this method is deprecated."""
-        warnings.warn("'Retrying.call()' method is deprecated. " +
-                      "Use 'Retrying.__call__()' instead", DeprecationWarning)
-        return self.__call__(*args, **kwargs)
 
 
 class Future(futures.Future):

--- a/tenacity/tests/test_asyncio.py
+++ b/tenacity/tests/test_asyncio.py
@@ -17,6 +17,8 @@ import asyncio
 import inspect
 import unittest
 
+import pytest
+
 import six
 
 from tenacity import AsyncRetrying, RetryError
@@ -69,6 +71,14 @@ class TestAsync(unittest.TestCase):
         thing = NoIOErrorAfterCount(5)
         retrying = AsyncRetrying()
         await retrying(_async_function, thing)
+        assert thing.counter == thing.count
+
+    @asynctest
+    async def test_retry_using_async_retying_legacy_method(self):
+        thing = NoIOErrorAfterCount(5)
+        retrying = AsyncRetrying()
+        with pytest.warns(DeprecationWarning):
+            await retrying.call(_async_function, thing)
         assert thing.counter == thing.count
 
     @asynctest


### PR DESCRIPTION
#253 made `Retrying` and `AsyncRetrying` (and `BaseRetrying` itself) callable, but it broke compatibility of `AsyncRetrying` by removing the legacy `call` method.

This moves the deprecated `call` method to the base class to regain compatibility since no major versions were released