### PR TITLE
avoid including tests when packaging

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,9 @@ install_requires =
     typing>=3.7.4.1;python_version=='2.7'
 packages = tenacity
 
+[options.packages.find]
+exclude = tests
+
 [options.package_data]
 tenacity = py.typed
 


### PR DESCRIPTION
It seems to me that "tests" folder should not be distributed to users.