### PR TITLE
ci(mergify): force release notes to be present

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,15 @@
 pull_request_rules:
-  - name: automatic merge
+  - name: warn on no changelog
+    conditions:
+      - -files~=^releasenotes/notes/
+      - label!=no-changelog
+    actions:
+      comment:
+        message: |
+          ⚠️ No release notes detected. Please make sure to use
+          [reno](https://docs.openstack.org/reno/latest/user/usage.html) to add
+          a changelog entry.
+  - name: automatic merge without changelog
     conditions:
       - "status-success=ci/circleci: pep8"
       - "status-success=ci/circleci: py27"
@@ -9,12 +19,27 @@ pull_request_rules:
       - "status-success=ci/circleci: py38"
       - "status-success=ci/circleci: py39"
       - "#approved-reviews-by>=1"
-      - label!=work-in-progress
+      - label=no-changelog
     actions:
       merge:
         strict: "smart"
         method: squash
-  - name: automatic merge for jd
+  - name: automatic merge with changelog
+    conditions:
+      - "status-success=ci/circleci: pep8"
+      - "status-success=ci/circleci: py27"
+      - "status-success=ci/circleci: py35"
+      - "status-success=ci/circleci: py36"
+      - "status-success=ci/circleci: py37"
+      - "status-success=ci/circleci: py38"
+      - "status-success=ci/circleci: py39"
+      - "#approved-reviews-by>=1"
+      - files~=^releasenotes/notes/
+    actions:
+      merge:
+        strict: "smart"
+        method: squash
+  - name: automatic merge for jd without changelog
     conditions:
       - author=jd
       - "status-success=ci/circleci: pep8"
@@ -24,7 +49,22 @@ pull_request_rules:
       - "status-success=ci/circleci: py37"
       - "status-success=ci/circleci: py38"
       - "status-success=ci/circleci: py39"
-      - label!=work-in-progress
+      - label=no-changelog
+    actions:
+      merge:
+        strict: "smart"
+        method: squash
+  - name: automatic merge for jd with changelog
+    conditions:
+      - author=jd
+      - "status-success=ci/circleci: pep8"
+      - "status-success=ci/circleci: py27"
+      - "status-success=ci/circleci: py35"
+      - "status-success=ci/circleci: py36"
+      - "status-success=ci/circleci: py37"
+      - "status-success=ci/circleci: py38"
+      - "status-success=ci/circleci: py39"
+      - files~=^releasenotes/notes/
     actions:
       merge:
         strict: "smart"


### PR DESCRIPTION
This should make sure we don't forget to put a release note before merging a
PR.

Related to #284
