### PR TITLE
Add support for an async defined retry and callback_error_retry

### DIFF
--- a/tenacity/_asyncio.py
+++ b/tenacity/_asyncio.py
@@ -15,10 +15,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import six
+
+try:
+    from inspect import iscoroutinefunction
+except ImportError:
+    iscoroutinefunction = None
+
 import sys
 from asyncio import sleep
 
-from tenacity import AttemptManager
+from tenacity import AttemptManager, TryAgain, RetryAction
 from tenacity import BaseRetrying
 from tenacity import DoAttempt
 from tenacity import DoSleep
@@ -30,12 +37,58 @@ class AsyncRetrying(BaseRetrying):
         super(AsyncRetrying, self).__init__(**kwargs)
         self.sleep = sleep
 
+    async def iter(self, retry_state):  # noqa
+        fut = retry_state.outcome
+        if fut is None:
+            if self.before is not None:
+                self.before(retry_state)
+            return DoAttempt()
+
+        is_explicit_retry = retry_state.outcome.failed and isinstance(
+            retry_state.outcome.exception(), TryAgain
+        )
+        if iscoroutinefunction(self.retry):
+            should_retry = await self.retry(retry_state=retry_state)
+        else:
+            should_retry = self.retry(retry_state=retry_state)
+        if not (is_explicit_retry or should_retry):
+            return fut.result()
+
+        if self.after is not None:
+            self.after(retry_state=retry_state)
+
+        self.statistics["delay_since_first_attempt"] = retry_state.seconds_since_start
+        if self.stop(retry_state=retry_state):
+            if self.retry_error_callback:
+                if iscoroutinefunction(self.retry_error_callback):
+                    return await self.retry_error_callback(retry_state=retry_state)
+                else:
+                    return self.retry_error_callback(retry_state=retry_state)
+            retry_exc = self.retry_error_cls(fut)
+            if self.reraise:
+                raise retry_exc.reraise()
+            six.raise_from(retry_exc, fut.exception())
+
+        if self.wait:
+            iteration_sleep = self.wait(retry_state=retry_state)
+        else:
+            iteration_sleep = 0.0
+        retry_state.next_action = RetryAction(iteration_sleep)
+        retry_state.idle_for += iteration_sleep
+        self.statistics["idle_for"] += iteration_sleep
+        self.statistics["attempt_number"] += 1
+
+        if self.before_sleep is not None:
+            self.before_sleep(retry_state=retry_state)
+
+        return DoSleep(iteration_sleep)
+
     async def __call__(self, fn, *args, **kwargs):
         self.begin(fn)
 
         retry_state = RetryCallState(retry_object=self, fn=fn, args=args, kwargs=kwargs)
         while True:
-            do = self.iter(retry_state=retry_state)
+            do = await self.iter(retry_state=retry_state)
             if isinstance(do, DoAttempt):
                 try:
                     result = await fn(*args, **kwargs)
@@ -56,7 +109,7 @@ class AsyncRetrying(BaseRetrying):
 
     async def __anext__(self):
         while True:
-            do = self.iter(retry_state=self._retry_state)
+            do = await self.iter(retry_state=self._retry_state)
             if do is None:
                 raise StopAsyncIteration
             elif isinstance(do, DoAttempt):
@@ -69,6 +122,7 @@ class AsyncRetrying(BaseRetrying):
 
     def wraps(self, fn):
         fn = super().wraps(fn)
+
         # Ensure wrapper is recognized as a coroutine function.
 
         async def async_wrapped(*args, **kwargs):


### PR DESCRIPTION
This issue raises the need for an asynchronously defined error callback: #249 

This is a first approach to be able to use an asynchronously defined retry (on every retry iteration) and callback_error_retry (after the retrying is stopped)

- I added tests for both
- I added an await in __call__ and __anext__ to be able to use the context manager (passed async context manager tests)
- I had to override the iter() in AsyncRetrying to define it as async 
 