### PR TITLE
Before sleep log stack info

### DIFF
--- a/releasenotes/notes/before_sleep_log-stack_info-ec404d38a82f4f9d.yaml
+++ b/releasenotes/notes/before_sleep_log-stack_info-ec404d38a82f4f9d.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Add a ``stack_info`` option to the ``before_sleep_log()`` strategy.

--- a/tenacity/before_sleep.py
+++ b/tenacity/before_sleep.py
@@ -22,7 +22,7 @@ def before_sleep_nothing(retry_state):
     """Before call strategy that does nothing."""
 
 
-def before_sleep_log(logger, log_level, exc_info=False):
+def before_sleep_log(logger, log_level, exc_info=False, stack_info=False):
     """Before call strategy that logs to some logger the attempt."""
 
     def log_it(retry_state):
@@ -46,6 +46,7 @@ def before_sleep_log(logger, log_level, exc_info=False):
             verb,
             value,
             exc_info=local_exc_info,
+            stack_info=stack_info,
         )
 
     return log_it


### PR DESCRIPTION
This change adds the `stack_info` parameter to the before_sleep_log() function and passes it to the logger function.  When set to True, logger will include a stack dump at the current location, which can be useful to pinpointing the exact location in code that triggered a retry.

Closes #290