### PR TITLE
Drop support for deprecated Pythons

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,24 +10,6 @@ jobs:
           command: |
             sudo pip install tox
             tox -e pep8
-  py27:
-    docker:
-      - image: circleci/python:2.7
-    steps:
-      - checkout
-      - run:
-          command: |
-            sudo pip install tox
-            tox -e py27
-  py35:
-    docker:
-      - image: circleci/python:3.5
-    steps:
-      - checkout
-      - run:
-          command: |
-            sudo pip install tox
-            tox -e py35
   py36:
     docker:
       - image: circleci/python:3.6
@@ -94,8 +76,6 @@ workflows:
   test:
     jobs:
       - pep8
-      - py27
-      - py35
       - py36
       - py37
       - py38

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,8 +13,6 @@ pull_request_rules:
   - name: automatic merge without changelog
     conditions:
       - "status-success=ci/circleci: pep8"
-      - "status-success=ci/circleci: py27"
-      - "status-success=ci/circleci: py35"
       - "status-success=ci/circleci: py36"
       - "status-success=ci/circleci: py37"
       - "status-success=ci/circleci: py38"
@@ -28,8 +26,6 @@ pull_request_rules:
   - name: automatic merge with changelog
     conditions:
       - "status-success=ci/circleci: pep8"
-      - "status-success=ci/circleci: py27"
-      - "status-success=ci/circleci: py35"
       - "status-success=ci/circleci: py36"
       - "status-success=ci/circleci: py37"
       - "status-success=ci/circleci: py38"
@@ -44,8 +40,6 @@ pull_request_rules:
     conditions:
       - author=jd
       - "status-success=ci/circleci: pep8"
-      - "status-success=ci/circleci: py27"
-      - "status-success=ci/circleci: py35"
       - "status-success=ci/circleci: py36"
       - "status-success=ci/circleci: py37"
       - "status-success=ci/circleci: py38"
@@ -59,8 +53,6 @@ pull_request_rules:
     conditions:
       - author=jd
       - "status-success=ci/circleci: pep8"
-      - "status-success=ci/circleci: py27"
-      - "status-success=ci/circleci: py35"
       - "status-success=ci/circleci: py36"
       - "status-success=ci/circleci: py37"
       - "status-success=ci/circleci: py38"

--- a/releasenotes/notes/drop-deprecated-python-versions-69a05cb2e0f1034c.yaml
+++ b/releasenotes/notes/drop-deprecated-python-versions-69a05cb2e0f1034c.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    Drop support for deprecated Python versions (2.7 and 3.5)

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,10 +11,8 @@ classifier =
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -24,9 +22,7 @@ classifier =
 [options]
 install_requires =
     six>=1.9.0
-    futures>=3.0;python_version=='2.7'
-    monotonic>=0.6;python_version=='2.7'
-    typing>=3.7.4.1;python_version=='2.7'
+python_requires = >=3.6
 packages = tenacity
 
 [options.packages.find]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, py39, pep8, pypy
+envlist = py36, py37, py38, py39, pep8, pypy3
 
 [testenv]
 usedevelop = True
@@ -7,12 +7,11 @@ sitepackages = False
 deps =
     .[doc]
     pytest
-    typeguard;python_version>='3.0'
+    typeguard
 commands =
-    py{27,py}: pytest --ignore='tenacity/tests/test_asyncio.py' {posargs}
-    py3{5,6,7,8,9}: pytest {posargs}
-    py3{5,6,7,8,9}: sphinx-build -a -E -W -b doctest doc/source doc/build
-    py3{5,6,7,8,9}: sphinx-build -a -E -W -b html doc/source doc/build
+    py{36,37,38,39,py3}: pytest {posargs}
+    py{36,37,38,39,py3}: sphinx-build -a -E -W -b doctest doc/source doc/build
+    py{36,37,38,39,py3}: sphinx-build -a -E -W -b html doc/source doc/build
 
 [testenv:pep8]
 basepython = python3


### PR DESCRIPTION
This PR obsoletes Python 2.7 & 3.5, removes them from package metadata and CI. Also, it adds the `python_requires` metadata option which instructs `pip` running on older Python versions to find and install the latest suitable release.

See #291 