### PR TITLE
Support Trio out-of-the-box

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,15 @@ jobs:
           command: |
             sudo pip install tox
             tox -e py39
+  py39-notrio:
+    docker:
+      - image: circleci/python:3.9
+    steps:
+      - checkout
+      - run:
+          command: |
+            sudo pip install tox
+            tox -e py39-notrio
   deploy:
     docker:
       - image: circleci/python:3.9
@@ -100,6 +109,7 @@ workflows:
       - py37
       - py38
       - py39
+      - py39-notrio
       - deploy:
           filters:
             tags:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -546,28 +546,34 @@ With async code you can use AsyncRetrying.
 Async and retry
 ~~~~~~~~~~~~~~~
 
-Finally, ``retry`` works also on asyncio and Tornado (>= 4.5) coroutines.
+Finally, ``retry`` works also on asyncio, Trio, and Tornado (>= 4.5) coroutines.
 Sleeps are done asynchronously too.
 
 .. code-block:: python
 
     @retry
-    async def my_async_function(loop):
+    async def my_asyncio_function(loop):
         await loop.getaddrinfo('8.8.8.8', 53)
 
 .. code-block:: python
 
     @retry
-    @tornado.gen.coroutine
-    def my_async_function(http_client, url):
-        yield http_client.fetch(url)
-
-You can even use alternative event loops such as `curio` or `Trio` by passing the correct sleep function:
+    def my_async_trio_function():
+        await trio.socket.getaddrinfo('8.8.8.8', 53)
 
 .. code-block:: python
 
-    @retry(sleep=trio.sleep)
-    async def my_async_function(loop):
+    @retry
+    @tornado.gen.coroutine
+    def my_async_tornado_function(http_client, url):
+        yield http_client.fetch(url)
+
+You can even use alternative event loops such as `curio` by passing the correct sleep function:
+
+.. code-block:: python
+
+    @retry(sleep=curio.sleep)
+    async def my_async_curio_function():
         await asks.get('https://example.org')
 
 Contribute

--- a/releasenotes/notes/trio-support-62fed9e32ccb62be.yaml
+++ b/releasenotes/notes/trio-support-62fed9e32ccb62be.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    If you're using `Trio <https://trio.readthedocs.io>`__, then
+    ``@retry`` now works automatically. It's no longer necessary to
+    pass ``sleep=trio.sleep``.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, py39, py39-notrio, pep8, pypy
+envlist = py27, py35, py36, py37, py38, py39, py39-trio, pep8, pypy
 
 [testenv]
 usedevelop = True
@@ -7,7 +7,6 @@ sitepackages = False
 deps =
     .[doc]
     pytest
-    trio
     typeguard;python_version>='3.0'
 commands =
     py{27,py}: pytest --ignore='tenacity/tests/test_asyncio.py' {posargs}
@@ -15,10 +14,11 @@ commands =
     py3{5,6,7,8,9}: sphinx-build -a -E -W -b doctest doc/source doc/build
     py3{5,6,7,8,9}: sphinx-build -a -E -W -b html doc/source doc/build
 
-[testenv:py39-notrio]
+[testenv:py39-trio]
 deps =
     .[doc]
     pytest
+    trio
     typeguard;python_version>='3.0'
 commands = pytest {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ sitepackages = False
 deps =
     .[doc]
     pytest
+    trio
     typeguard;python_version>='3.0'
 commands =
     py{27,py}: pytest --ignore='tenacity/tests/test_asyncio.py' {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, py39, pep8, pypy
+envlist = py27, py35, py36, py37, py38, py39, py39-notrio, pep8, pypy
 
 [testenv]
 usedevelop = True
@@ -14,6 +14,13 @@ commands =
     py3{5,6,7,8,9}: pytest {posargs}
     py3{5,6,7,8,9}: sphinx-build -a -E -W -b doctest doc/source doc/build
     py3{5,6,7,8,9}: sphinx-build -a -E -W -b html doc/source doc/build
+
+[testenv:py39-notrio]
+deps =
+    .[doc]
+    pytest
+    typeguard;python_version>='3.0'
+commands = pytest {posargs}
 
 [testenv:pep8]
 basepython = python3


### PR DESCRIPTION
This PR makes `@retry` just work when running under Trio.

For now, I added `trio` to the test deps in tox.ini, so we can test
it. The code is also designed to handle things gracefully if trio
isn't installed, but currently there's not any automated test for
that... how would you like to handle this? Maybe add another
test environment without trio?