### PR TITLE
Use black instead of "flake8-black" on CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,15 @@ jobs:
           command: |
             sudo pip install tox
             tox -e pep8
+  black:
+    docker:
+      - image: circleci/python:3.9
+    steps:
+      - checkout
+      - run:
+          command: |
+            sudo pip install tox
+            tox -e black-ci
   py36:
     docker:
       - image: circleci/python:3.6
@@ -76,6 +85,7 @@ workflows:
   test:
     jobs:
       - pep8
+      - black
       - py36
       - py37
       - py38

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{py,pyx,pxd,pyi}]
+indent_size = 4
+max_line_length = 120
+
+[*.ini]
+indent_size = 4
+
+[*.rst]
+max_line_length = 150
+
+[Makefile]
+indent_style = tab

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,6 +13,7 @@ pull_request_rules:
   - name: automatic merge without changelog
     conditions:
       - "status-success=ci/circleci: pep8"
+      - "status-success=ci/circleci: black"
       - "status-success=ci/circleci: py36"
       - "status-success=ci/circleci: py37"
       - "status-success=ci/circleci: py38"
@@ -26,6 +27,7 @@ pull_request_rules:
   - name: automatic merge with changelog
     conditions:
       - "status-success=ci/circleci: pep8"
+      - "status-success=ci/circleci: black"
       - "status-success=ci/circleci: py36"
       - "status-success=ci/circleci: py37"
       - "status-success=ci/circleci: py38"
@@ -40,6 +42,7 @@ pull_request_rules:
     conditions:
       - author=jd
       - "status-success=ci/circleci: pep8"
+      - "status-success=ci/circleci: black"
       - "status-success=ci/circleci: py36"
       - "status-success=ci/circleci: py37"
       - "status-success=ci/circleci: py38"
@@ -53,6 +56,7 @@ pull_request_rules:
     conditions:
       - author=jd
       - "status-success=ci/circleci: pep8"
+      - "status-success=ci/circleci: black"
       - "status-success=ci/circleci: py36"
       - "status-success=ci/circleci: py37"
       - "status-success=ci/circleci: py38"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+# PEP 508 specifications for PEP 518.
+# Banned setuptools versions have well-known issues
+requires = [
+  "setuptools >= 21.0.0,!=24.0.0,!=34.0.0,!=34.0.1,!=34.0.2,!=34.0.3,!=34.1.0,!=34.1.1,!=34.2.0,!=34.3.0,!=34.3.1,!=34.3.2,!=36.2.0",  # PSF/ZPL
+  "setuptools_scm[toml]>=3.4",
+]
+build-backend="setuptools.build_meta"
+
+[tool.black]
+line-length = 120
+safe = true
+target-version = ["py36", "py37", "py38", "py39"]
+
+[tool.setuptools_scm]

--- a/releasenotes/notes/Use--for-formatting-and-validate-using-black-39ec9d57d4691778.yaml
+++ b/releasenotes/notes/Use--for-formatting-and-validate-using-black-39ec9d57d4691778.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - "Use `black` for code formatting and validate using `black --check`. Code compatibility: py26-py39."
+  - "Enforce maximal line length to 120 symbols"

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,8 +5,8 @@ url = https://github.com/jd/tenacity
 summary = Retry code until it succeeds
 long_description = Tenacity is a general-purpose retrying library to simplify the task of adding retry behavior to just about anything.
 author = Julien Danjou
-author-email = julien@danjou.info
-home-page = https://github.com/jd/tenacity
+author_email = julien@danjou.info
+home_page = https://github.com/jd/tenacity
 classifier =
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -126,11 +126,7 @@ def retry(*dargs: t.Any, **dkw: t.Any) -> t.Union[WrappedFn, t.Callable[[Wrapped
                 )
             if iscoroutinefunction is not None and iscoroutinefunction(f):
                 r: "BaseRetrying" = AsyncRetrying(*dargs, **dkw)
-            elif (
-                tornado
-                and hasattr(tornado.gen, "is_coroutine_function")
-                and tornado.gen.is_coroutine_function(f)
-            ):
+            elif tornado and hasattr(tornado.gen, "is_coroutine_function") and tornado.gen.is_coroutine_function(f):
                 r = TornadoRetrying(*dargs, **dkw)
             else:
                 r = Retrying(*dargs, **dkw)
@@ -168,9 +164,7 @@ class BaseAction:
     NAME: t.Optional[str] = None
 
     def __repr__(self) -> str:
-        state_str = ", ".join(
-            "%s=%r" % (field, getattr(self, field)) for field in self.REPR_FIELDS
-        )
+        state_str = ", ".join("%s=%r" % (field, getattr(self, field)) for field in self.REPR_FIELDS)
         return "%s(%s)" % (type(self).__name__, state_str)
 
     def __str__(self) -> str:
@@ -218,10 +212,10 @@ class AttemptManager:
         pass
 
     def __exit__(
-            self,  # noqa:BLK100
-            exc_type: t.Optional[t.Type[BaseException]],
-            exc_value: t.Optional[BaseException],
-            traceback: t.Optional["types.TracebackType"],
+        self,
+        exc_type: t.Optional[t.Type[BaseException]],
+        exc_value: t.Optional[BaseException],
+        traceback: t.Optional["types.TracebackType"],
     ) -> t.Optional[bool]:
         if isinstance(exc_value, BaseException):
             self.retry_state.set_exception((exc_type, exc_value, traceback))
@@ -233,7 +227,6 @@ class AttemptManager:
 
 
 class BaseRetrying(metaclass=ABCMeta):
-
     def __init__(
         self,
         sleep: t.Callable[[t.Union[int, float]], None] = sleep,
@@ -287,9 +280,7 @@ class BaseRetrying(metaclass=ABCMeta):
             before_sleep=_first_set(before_sleep, self.before_sleep),
             reraise=_first_set(reraise, self.reraise),
             retry_error_cls=_first_set(retry_error_cls, self.retry_error_cls),
-            retry_error_callback=_first_set(
-                retry_error_callback, self.retry_error_callback
-            ),
+            retry_error_callback=_first_set(retry_error_callback, self.retry_error_callback),
         )
 
     def __repr__(self) -> str:
@@ -363,9 +354,7 @@ class BaseRetrying(metaclass=ABCMeta):
                 self.before(retry_state)
             return DoAttempt()
 
-        is_explicit_retry = retry_state.outcome.failed and isinstance(
-            retry_state.outcome.exception(), TryAgain
-        )
+        is_explicit_retry = retry_state.outcome.failed and isinstance(retry_state.outcome.exception(), TryAgain)
         if not (is_explicit_retry or self.retry(retry_state=retry_state)):
             return fut.result()
 
@@ -472,11 +461,11 @@ class RetryCallState:
     """State related to a single call wrapped with Retrying."""
 
     def __init__(
-            self,
-            retry_object: BaseRetrying,
-            fn: t.Optional[WrappedFn],
-            args: t.Any,
-            kwargs: t.Any,
+        self,
+        retry_object: BaseRetrying,
+        fn: t.Optional[WrappedFn],
+        args: t.Any,
+        kwargs: t.Any,
     ) -> None:
         #: Retry call start timestamp
         self.start_time = time.monotonic()
@@ -496,7 +485,7 @@ class RetryCallState:
         #: Timestamp of the last outcome
         self.outcome_timestamp: t.Optional[float] = None
         #: Time spent sleeping in retries
-        self.idle_for: float = 0.
+        self.idle_for: float = 0.0
         #: Next action as decided by the retry manager
         self.next_action: t.Optional[RetryAction] = None
 

--- a/tenacity/before.py
+++ b/tenacity/before.py
@@ -28,7 +28,7 @@ def before_nothing(retry_state: "RetryCallState") -> None:
     """Before call strategy that does nothing."""
 
 
-def before_log(logger: "logging.Logger", log_level: int) -> typing.Callable[["RetryCallState"], None]:  # noqa:BLK100
+def before_log(logger: "logging.Logger", log_level: int) -> typing.Callable[["RetryCallState"], None]:
     """Before call strategy that logs to some logger the attempt."""
 
     def log_it(retry_state: "RetryCallState") -> None:

--- a/tenacity/retry.py
+++ b/tenacity/retry.py
@@ -79,7 +79,7 @@ class retry_if_exception_type(retry_if_exception):
         exception_types: typing.Union[
             typing.Type[BaseException],
             typing.Tuple[typing.Type[BaseException], ...],
-        ] = Exception,  # noqa:BLK100
+        ] = Exception,
     ) -> None:
         self.exception_types = exception_types
         super().__init__(lambda e: isinstance(e, exception_types))
@@ -89,11 +89,11 @@ class retry_if_not_exception_type(retry_if_exception):
     """Retries except an exception has been raised of one or more types."""
 
     def __init__(
-            self,  # noqa:BLK100
-            exception_types: typing.Union[
-                typing.Type[BaseException],
-                typing.Tuple[typing.Type[BaseException], ...],
-            ] = Exception,
+        self,
+        exception_types: typing.Union[
+            typing.Type[BaseException],
+            typing.Tuple[typing.Type[BaseException], ...],
+        ] = Exception,
     ) -> None:
         self.exception_types = exception_types
         super().__init__(lambda e: not isinstance(e, exception_types))
@@ -103,11 +103,11 @@ class retry_unless_exception_type(retry_if_exception):
     """Retries until an exception is raised of one or more types."""
 
     def __init__(
-            self,
-            exception_types: typing.Union[
-                typing.Type[BaseException],
-                typing.Tuple[typing.Type[BaseException], ...],
-            ] = Exception
+        self,
+        exception_types: typing.Union[
+            typing.Type[BaseException],
+            typing.Tuple[typing.Type[BaseException], ...],
+        ] = Exception,
     ) -> None:
         self.exception_types = exception_types
         super().__init__(lambda e: not isinstance(e, exception_types))
@@ -154,11 +154,7 @@ class retry_if_exception_message(retry_if_exception):
         match: typing.Optional[str] = None,
     ) -> None:
         if message and match:
-            raise TypeError(
-                "{}() takes either 'message' or 'match', not both".format(
-                    self.__class__.__name__
-                )
-            )
+            raise TypeError("{}() takes either 'message' or 'match', not both".format(self.__class__.__name__))
 
         # set predicate
         if message:
@@ -175,11 +171,7 @@ class retry_if_exception_message(retry_if_exception):
 
             predicate = match_fnc
         else:
-            raise TypeError(
-                "{}() missing 1 required argument 'message' or 'match'".format(
-                    self.__class__.__name__
-                )
-            )
+            raise TypeError("{}() missing 1 required argument 'message' or 'match'".format(self.__class__.__name__))
 
         super().__init__(predicate)
 
@@ -188,9 +180,9 @@ class retry_if_not_exception_message(retry_if_exception_message):
     """Retries until an exception message equals or matches."""
 
     def __init__(
-            self,
-            message: typing.Optional[str] = None,
-            match: typing.Optional[str] = None,
+        self,
+        message: typing.Optional[str] = None,
+        match: typing.Optional[str] = None,
     ) -> None:
         super().__init__(message, match)
         # invert predicate

--- a/tenacity/tests/test_asyncio.py
+++ b/tenacity/tests/test_asyncio.py
@@ -145,9 +145,7 @@ class TestContextManager(unittest.TestCase):
             pass
 
         try:
-            async for attempt in tasyncio.AsyncRetrying(
-                stop=stop_after_attempt(1), reraise=True
-            ):
+            async for attempt in tasyncio.AsyncRetrying(stop=stop_after_attempt(1), reraise=True):
                 with attempt:
                     raise CustomError()
         except CustomError:
@@ -159,9 +157,7 @@ class TestContextManager(unittest.TestCase):
     async def test_sleeps(self):
         start = current_time_ms()
         try:
-            async for attempt in tasyncio.AsyncRetrying(
-                stop=stop_after_attempt(1), wait=wait_fixed(1)
-            ):
+            async for attempt in tasyncio.AsyncRetrying(stop=stop_after_attempt(1), wait=wait_fixed(1)):
                 with attempt:
                     raise Exception()
         except RetryError:

--- a/tenacity/tests/test_tenacity.py
+++ b/tenacity/tests/test_tenacity.py
@@ -52,16 +52,12 @@ def _set_delay_since_start(retry_state, delay):
     assert retry_state.seconds_since_start == delay
 
 
-def make_retry_state(
-    previous_attempt_number, delay_since_first_attempt, last_result=None
-):
+def make_retry_state(previous_attempt_number, delay_since_first_attempt, last_result=None):
     """Construct RetryCallState for given attempt number & delay.
 
     Only used in testing and thus is extra careful about timestamp arithmetics.
     """
-    required_parameter_unset = (
-        previous_attempt_number is _unset or delay_since_first_attempt is _unset
-    )
+    required_parameter_unset = previous_attempt_number is _unset or delay_since_first_attempt is _unset
     if required_parameter_unset:
         raise _make_unset_exception(
             "wait/stop",
@@ -94,9 +90,7 @@ class TestStopConditions(unittest.TestCase):
         self.assertFalse(r.stop(make_retry_state(3, 6546)))
 
     def test_stop_any(self):
-        stop = tenacity.stop_any(
-            tenacity.stop_after_delay(1), tenacity.stop_after_attempt(4)
-        )
+        stop = tenacity.stop_any(tenacity.stop_after_delay(1), tenacity.stop_after_attempt(4))
 
         def s(*args):
             return stop(make_retry_state(*args))
@@ -109,9 +103,7 @@ class TestStopConditions(unittest.TestCase):
         self.assertTrue(s(4, 1.8))
 
     def test_stop_all(self):
-        stop = tenacity.stop_all(
-            tenacity.stop_after_delay(1), tenacity.stop_after_attempt(4)
-        )
+        stop = tenacity.stop_all(tenacity.stop_after_delay(1), tenacity.stop_after_attempt(4))
 
         def s(*args):
             return stop(make_retry_state(*args))
@@ -301,11 +293,7 @@ class TestWaitConditions(unittest.TestCase):
         self.assertEqual(r.wait(make_retry_state(10, 100)), 1000)
 
     def test_wait_combine(self):
-        r = Retrying(
-            wait=tenacity.wait_combine(
-                tenacity.wait_random(0, 3), tenacity.wait_fixed(5)
-            )
-        )
+        r = Retrying(wait=tenacity.wait_combine(tenacity.wait_random(0, 3), tenacity.wait_fixed(5)))
         # Test it a few time since it's random
         for i in range(1000):
             w = r.wait(make_retry_state(1, 5))
@@ -321,11 +309,7 @@ class TestWaitConditions(unittest.TestCase):
             self.assertGreaterEqual(w, 5)
 
     def test_wait_triple_sum(self):
-        r = Retrying(
-            wait=tenacity.wait_fixed(1)
-            + tenacity.wait_random(0, 3)
-            + tenacity.wait_fixed(5)
-        )
+        r = Retrying(wait=tenacity.wait_fixed(1) + tenacity.wait_random(0, 3) + tenacity.wait_fixed(5))
         # Test it a few time since it's random
         for i in range(1000):
             w = r.wait(make_retry_state(1, 5))
@@ -455,10 +439,7 @@ class TestWaitConditions(unittest.TestCase):
 
         retrying = Retrying(
             wait=waitfunc,
-            retry=(
-                tenacity.retry_if_exception_type()
-                | tenacity.retry_if_result(lambda result: result == 123)
-            ),
+            retry=(tenacity.retry_if_exception_type() | tenacity.retry_if_result(lambda result: result == 123)),
         )
 
         def returnval():
@@ -542,9 +523,7 @@ class TestRetryConditions(unittest.TestCase):
         self.assertFalse(r(tenacity.Future.construct(1, 1, True)))
 
     def test_retry_and(self):
-        retry = tenacity.retry_if_result(lambda x: x == 1) & tenacity.retry_if_result(
-            lambda x: isinstance(x, int)
-        )
+        retry = tenacity.retry_if_result(lambda x: x == 1) & tenacity.retry_if_result(lambda x: isinstance(x, int))
 
         def r(fut):
             retry_state = make_retry_state(1, 1.0, last_result=fut)
@@ -556,9 +535,7 @@ class TestRetryConditions(unittest.TestCase):
         self.assertFalse(r(tenacity.Future.construct(1, 1, True)))
 
     def test_retry_or(self):
-        retry = tenacity.retry_if_result(
-            lambda x: x == "foo"
-        ) | tenacity.retry_if_result(lambda x: isinstance(x, int))
+        retry = tenacity.retry_if_result(lambda x: x == "foo") | tenacity.retry_if_result(lambda x: isinstance(x, int))
 
         def r(fut):
             retry_state = make_retry_state(1, 1.0, last_result=fut)
@@ -576,9 +553,7 @@ class TestRetryConditions(unittest.TestCase):
 
     def test_retry_try_again(self):
         self._attempts = 0
-        Retrying(stop=tenacity.stop_after_attempt(5), retry=tenacity.retry_never)(
-            self._raise_try_again
-        )
+        Retrying(stop=tenacity.stop_after_attempt(5), retry=tenacity.retry_never)(self._raise_try_again)
         self.assertEqual(3, self._attempts)
 
     def test_retry_try_again_forever(self):
@@ -781,9 +756,7 @@ def _retryable_test_if_not_exception_type_io(thing):
     return thing.go()
 
 
-@retry(
-    stop=tenacity.stop_after_attempt(3), retry=tenacity.retry_if_exception_type(IOError)
-)
+@retry(stop=tenacity.stop_after_attempt(3), retry=tenacity.retry_if_exception_type(IOError))
 def _retryable_test_with_exception_type_io_attempt_limit(thing):
     return thing.go()
 
@@ -808,46 +781,28 @@ def _retryable_test_with_unless_exception_type_no_input(thing):
 
 @retry(
     stop=tenacity.stop_after_attempt(5),
-    retry=tenacity.retry_if_exception_message(
-        message=NoCustomErrorAfterCount.derived_message
-    ),
+    retry=tenacity.retry_if_exception_message(message=NoCustomErrorAfterCount.derived_message),
 )
 def _retryable_test_if_exception_message_message(thing):
     return thing.go()
 
 
-@retry(
-    retry=tenacity.retry_if_not_exception_message(
-        message=NoCustomErrorAfterCount.derived_message
-    )
-)
+@retry(retry=tenacity.retry_if_not_exception_message(message=NoCustomErrorAfterCount.derived_message))
 def _retryable_test_if_not_exception_message_message(thing):
     return thing.go()
 
 
-@retry(
-    retry=tenacity.retry_if_exception_message(
-        match=NoCustomErrorAfterCount.derived_message[:3] + ".*"
-    )
-)
+@retry(retry=tenacity.retry_if_exception_message(match=NoCustomErrorAfterCount.derived_message[:3] + ".*"))
 def _retryable_test_if_exception_message_match(thing):
     return thing.go()
 
 
-@retry(
-    retry=tenacity.retry_if_not_exception_message(
-        match=NoCustomErrorAfterCount.derived_message[:3] + ".*"
-    )
-)
+@retry(retry=tenacity.retry_if_not_exception_message(match=NoCustomErrorAfterCount.derived_message[:3] + ".*"))
 def _retryable_test_if_not_exception_message_match(thing):
     return thing.go()
 
 
-@retry(
-    retry=tenacity.retry_if_not_exception_message(
-        message=NameErrorUntilCount.derived_message
-    )
-)
+@retry(retry=tenacity.retry_if_not_exception_message(message=NameErrorUntilCount.derived_message))
 def _retryable_test_not_exception_message_delay(thing):
     return thing.go()
 
@@ -911,9 +866,7 @@ class TestDecoratorWrapper(unittest.TestCase):
             self.assertTrue(isinstance(n, NameError))
             print(n)
 
-        self.assertTrue(
-            _retryable_test_with_exception_type_custom(NoCustomErrorAfterCount(5))
-        )
+        self.assertTrue(_retryable_test_with_exception_type_custom(NoCustomErrorAfterCount(5)))
 
         try:
             _retryable_test_with_exception_type_custom(NoNameErrorAfterCount(5))
@@ -923,9 +876,7 @@ class TestDecoratorWrapper(unittest.TestCase):
             print(n)
 
     def test_retry_except_exception_of_type(self):
-        self.assertTrue(
-            _retryable_test_if_not_exception_type_io(NoNameErrorAfterCount(5))
-        )
+        self.assertTrue(_retryable_test_if_not_exception_type_io(NoNameErrorAfterCount(5)))
 
         try:
             _retryable_test_if_not_exception_type_io(NoIOErrorAfterCount(5))
@@ -936,9 +887,7 @@ class TestDecoratorWrapper(unittest.TestCase):
 
     def test_retry_until_exception_of_type_attempt_number(self):
         try:
-            self.assertTrue(
-                _retryable_test_with_unless_exception_type_name(NameErrorUntilCount(5))
-            )
+            self.assertTrue(_retryable_test_with_unless_exception_type_name(NameErrorUntilCount(5)))
         except NameError as e:
             s = _retryable_test_with_unless_exception_type_name.retry.statistics
             self.assertTrue(s["attempt_number"] == 6)
@@ -949,11 +898,7 @@ class TestDecoratorWrapper(unittest.TestCase):
     def test_retry_until_exception_of_type_no_type(self):
         try:
             # no input should catch all subclasses of Exception
-            self.assertTrue(
-                _retryable_test_with_unless_exception_type_no_input(
-                    NameErrorUntilCount(5)
-                )
-            )
+            self.assertTrue(_retryable_test_with_unless_exception_type_no_input(NameErrorUntilCount(5)))
         except NameError as e:
             s = _retryable_test_with_unless_exception_type_no_input.retry.statistics
             self.assertTrue(s["attempt_number"] == 6)
@@ -964,9 +909,7 @@ class TestDecoratorWrapper(unittest.TestCase):
     def test_retry_until_exception_of_type_wrong_exception(self):
         try:
             # two iterations with IOError, one that returns True
-            _retryable_test_with_unless_exception_type_name_attempt_limit(
-                IOErrorUntilCount(2)
-            )
+            _retryable_test_with_unless_exception_type_name_attempt_limit(IOErrorUntilCount(2))
             self.fail("Expected RetryError")
         except RetryError as e:
             self.assertTrue(isinstance(e, RetryError))
@@ -974,29 +917,21 @@ class TestDecoratorWrapper(unittest.TestCase):
 
     def test_retry_if_exception_message(self):
         try:
-            self.assertTrue(
-                _retryable_test_if_exception_message_message(NoCustomErrorAfterCount(3))
-            )
+            self.assertTrue(_retryable_test_if_exception_message_message(NoCustomErrorAfterCount(3)))
         except CustomError:
             print(_retryable_test_if_exception_message_message.retry.statistics)
             self.fail("CustomError should've been retried from errormessage")
 
     def test_retry_if_not_exception_message(self):
         try:
-            self.assertTrue(
-                _retryable_test_if_not_exception_message_message(
-                    NoCustomErrorAfterCount(2)
-                )
-            )
+            self.assertTrue(_retryable_test_if_not_exception_message_message(NoCustomErrorAfterCount(2)))
         except CustomError:
             s = _retryable_test_if_not_exception_message_message.retry.statistics
             self.assertTrue(s["attempt_number"] == 1)
 
     def test_retry_if_not_exception_message_delay(self):
         try:
-            self.assertTrue(
-                _retryable_test_not_exception_message_delay(NameErrorUntilCount(3))
-            )
+            self.assertTrue(_retryable_test_not_exception_message_delay(NameErrorUntilCount(3)))
         except NameError:
             s = _retryable_test_not_exception_message_delay.retry.statistics
             print(s["attempt_number"])
@@ -1004,19 +939,13 @@ class TestDecoratorWrapper(unittest.TestCase):
 
     def test_retry_if_exception_message_match(self):
         try:
-            self.assertTrue(
-                _retryable_test_if_exception_message_match(NoCustomErrorAfterCount(3))
-            )
+            self.assertTrue(_retryable_test_if_exception_message_match(NoCustomErrorAfterCount(3)))
         except CustomError:
             self.fail("CustomError should've been retried from errormessage")
 
     def test_retry_if_not_exception_message_match(self):
         try:
-            self.assertTrue(
-                _retryable_test_if_not_exception_message_message(
-                    NoCustomErrorAfterCount(2)
-                )
-            )
+            self.assertTrue(_retryable_test_if_not_exception_message_message(NoCustomErrorAfterCount(2)))
         except CustomError:
             s = _retryable_test_if_not_exception_message_message.retry.statistics
             self.assertTrue(s["attempt_number"] == 1)
@@ -1038,9 +967,7 @@ class TestDecoratorWrapper(unittest.TestCase):
             def __call__(self):
                 return "Hello"
 
-        retrying = Retrying(
-            wait=tenacity.wait_fixed(0.01), stop=tenacity.stop_after_attempt(3)
-        )
+        retrying = Retrying(wait=tenacity.wait_fixed(0.01), stop=tenacity.stop_after_attempt(3))
         h = retrying.wraps(Hello())
         self.assertEqual(h(), "Hello")
 
@@ -1048,17 +975,13 @@ class TestDecoratorWrapper(unittest.TestCase):
 class TestRetryWith:
     def test_redefine_wait(self):
         start = current_time_ms()
-        result = _retryable_test_with_wait.retry_with(wait=tenacity.wait_fixed(0.1))(
-            NoneReturnUntilAfterCount(5)
-        )
+        result = _retryable_test_with_wait.retry_with(wait=tenacity.wait_fixed(0.1))(NoneReturnUntilAfterCount(5))
         t = current_time_ms() - start
         assert t >= 500
         assert result is True
 
     def test_redefine_stop(self):
-        result = _retryable_test_with_stop.retry_with(
-            stop=tenacity.stop_after_attempt(5)
-        )(NoneReturnUntilAfterCount(4))
+        result = _retryable_test_with_stop.retry_with(stop=tenacity.stop_after_attempt(5))(NoneReturnUntilAfterCount(4))
         assert result is True
 
     def test_retry_error_cls_should_be_preserved(self):
@@ -1163,10 +1086,7 @@ class TestBeforeAfterAttempts(unittest.TestCase):
         finally:
             logger.removeHandler(handler)
 
-        etalon_re = (
-            r"^Retrying .* in 0\.01 seconds as it raised "
-            r"(IO|OS)Error: Hi there, I'm an IOError\.$"
-        )
+        etalon_re = r"^Retrying .* in 0\.01 seconds as it raised " r"(IO|OS)Error: Hi there, I'm an IOError\.$"
         self.assertEqual(len(handler.records), 2)
         fmt = logging.Formatter().format
         self.assertRegexpMatches(fmt(handler.records[0]), etalon_re)
@@ -1186,9 +1106,7 @@ class TestBeforeAfterAttempts(unittest.TestCase):
         handler = CapturingHandler()
         logger.addHandler(handler)
         try:
-            _before_sleep = tenacity.before_sleep_log(
-                logger, logging.INFO, exc_info=True
-            )
+            _before_sleep = tenacity.before_sleep_log(logger, logging.INFO, exc_info=True)
             retrying = Retrying(
                 wait=tenacity.wait_fixed(0.01),
                 stop=tenacity.stop_after_attempt(3),
@@ -1218,9 +1136,7 @@ class TestBeforeAfterAttempts(unittest.TestCase):
         handler = CapturingHandler()
         logger.addHandler(handler)
         try:
-            _before_sleep = tenacity.before_sleep_log(
-                logger, logging.INFO, exc_info=exc_info
-            )
+            _before_sleep = tenacity.before_sleep_log(logger, logging.INFO, exc_info=exc_info)
             _retry = tenacity.retry_if_result(lambda result: result is None)
             retrying = Retrying(
                 wait=tenacity.wait_fixed(0.01),
@@ -1512,9 +1428,7 @@ class TestRetryException(unittest.TestCase):
 
 
 class TestRetryTyping(unittest.TestCase):
-    @pytest.mark.skipif(
-        sys.version_info < (3, 0), reason="typeguard not supported for python 2"
-    )
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="typeguard not supported for python 2")
     def test_retry_type_annotations(self):
         """The decorator should maintain types of decorated functions."""
         # Just in case this is run with unit-test, return early for py2

--- a/tenacity/wait.py
+++ b/tenacity/wait.py
@@ -68,9 +68,7 @@ class wait_random(wait_base):
         self.wait_random_max = max
 
     def __call__(self, retry_state: "RetryCallState") -> float:
-        return self.wait_random_min + (
-            random.random() * (self.wait_random_max - self.wait_random_min)
-        )
+        return self.wait_random_min + (random.random() * (self.wait_random_max - self.wait_random_min))
 
 
 class wait_combine(wait_base):

--- a/tox.ini
+++ b/tox.ini
@@ -23,8 +23,20 @@ deps = flake8
        flake8-docstrings
        flake8-rst-docstrings
        flake8-logging-format
-       flake8-black
 commands = flake8
+
+[testenv:black]
+deps =
+    black
+commands =
+    black .
+
+[testenv:black-ci]
+deps =
+    black
+    {[testenv:black]deps}
+commands =
+    black --check --diff .
 
 [testenv:reno]
 basepython = python3
@@ -36,3 +48,4 @@ exclude = .tox,.eggs
 show-source = true
 ignore = D100,D101,D102,D103,D104,D105,D107,G200,G201,W503,W504,E501
 enable-extensions=G
+max-line-length = 120


### PR DESCRIPTION
- Use `black` for code formatting and validate using `black --check`. Code compatibility: py26-py39.
- Enforce maximal line length to 120 symbols