### PR TITLE
Replace abc.ABCMeta with abc.ABC

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -23,7 +23,7 @@ import threading
 import time
 import typing as t
 import warnings
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from concurrent import futures
 from inspect import iscoroutinefunction
 
@@ -226,7 +226,7 @@ class AttemptManager:
             return None
 
 
-class BaseRetrying(metaclass=ABCMeta):
+class BaseRetrying(ABC):
     def __init__(
         self,
         sleep: t.Callable[[t.Union[int, float]], None] = sleep,

--- a/tenacity/retry.py
+++ b/tenacity/retry.py
@@ -24,7 +24,7 @@ if typing.TYPE_CHECKING:
     from tenacity import RetryCallState
 
 
-class retry_base(metaclass=abc.ABCMeta):
+class retry_base(abc.ABC):
     """Abstract base class for retry strategies."""
 
     @abc.abstractmethod

--- a/tenacity/stop.py
+++ b/tenacity/stop.py
@@ -24,7 +24,7 @@ if typing.TYPE_CHECKING:
     from tenacity import RetryCallState
 
 
-class stop_base(metaclass=abc.ABCMeta):
+class stop_base(abc.ABC):
     """Abstract base class for stop strategies."""
 
     @abc.abstractmethod

--- a/tenacity/wait.py
+++ b/tenacity/wait.py
@@ -26,7 +26,7 @@ if typing.TYPE_CHECKING:
     from tenacity import RetryCallState
 
 
-class wait_base(metaclass=abc.ABCMeta):
+class wait_base(abc.ABC):
     """Abstract base class for wait strategies."""
 
     @abc.abstractmethod


### PR DESCRIPTION
`abc.ABC` is available in Python 3.4+ and is a simpler alternative to `abc.ABCMeta`. As `tenacity` no longer supports Python 2.7, we could use it.