### PR TITLE
Fix issue #288 : __name__ and other attributes for async functions

### DIFF
--- a/releasenotes/notes/fix_async-52b6594c8e75c4bc.yaml
+++ b/releasenotes/notes/fix_async-52b6594c8e75c4bc.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - "Fix issue #288 : __name__ and other attributes for async functions"

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -118,7 +118,7 @@ def retry(*dargs: t.Any, **dkw: t.Any) -> t.Union[WrappedFn, t.Callable[[Wrapped
                     f"Got retry_base instance ({f.__class__.__name__}) as callable argument, "
                     f"this will probably hang indefinitely (did you mean retry={f.__class__.__name__}(...)?)"
                 )
-            if iscoroutinefunction is not None and iscoroutinefunction(f):
+            if iscoroutinefunction(f):
                 r: "BaseRetrying" = AsyncRetrying(*dargs, **dkw)
             elif tornado and hasattr(tornado.gen, "is_coroutine_function") and tornado.gen.is_coroutine_function(f):
                 r = TornadoRetrying(*dargs, **dkw)

--- a/tenacity/_asyncio.py
+++ b/tenacity/_asyncio.py
@@ -14,6 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import functools
 import sys
 from asyncio import sleep
 
@@ -70,6 +72,7 @@ class AsyncRetrying(BaseRetrying):
         fn = super().wraps(fn)
         # Ensure wrapper is recognized as a coroutine function.
 
+        @functools.wraps(fn)
         async def async_wrapped(*args, **kwargs):
             return await fn(*args, **kwargs)
 


### PR DESCRIPTION
`iscoroutinefunction` is always not Nons -> remove check