### PR TITLE
Fix #307 : Drop deprecated APIs

### DIFF
--- a/releasenotes/notes/drop_deprecated-7ea90b212509b082.yaml
+++ b/releasenotes/notes/drop_deprecated-7ea90b212509b082.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - "Removed `BaseRetrying.call`: was long time deprecated and produced `DeprecationWarning`"
+  - "Removed `BaseRetrying.fn`: was noted as deprecated"
+  - "API change: `BaseRetrying.begin()` do not require arguments anymore as it not setting `BaseRetrying.fn`"

--- a/tenacity/_asyncio.py
+++ b/tenacity/_asyncio.py
@@ -32,7 +32,7 @@ class AsyncRetrying(BaseRetrying):
         self.sleep = sleep
 
     async def __call__(self, fn, *args, **kwargs):
-        self.begin(fn)
+        self.begin()
 
         retry_state = RetryCallState(retry_object=self, fn=fn, args=args, kwargs=kwargs)
         while True:
@@ -51,7 +51,7 @@ class AsyncRetrying(BaseRetrying):
                 return do
 
     def __aiter__(self):
-        self.begin(None)
+        self.begin()
         self._retry_state = RetryCallState(self, fn=None, args=(), kwargs={})
         return self
 

--- a/tenacity/tornadoweb.py
+++ b/tenacity/tornadoweb.py
@@ -29,7 +29,7 @@ class TornadoRetrying(BaseRetrying):
 
     @gen.coroutine
     def __call__(self, fn, *args, **kwargs):
-        self.begin(fn)
+        self.begin()
 
         retry_state = RetryCallState(retry_object=self, fn=fn, args=args, kwargs=kwargs)
         while True:

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -18,8 +18,6 @@ import inspect
 import unittest
 from functools import wraps
 
-import pytest
-
 from tenacity import AsyncRetrying, RetryError
 from tenacity import _asyncio as tasyncio
 from tenacity import retry, stop_after_attempt
@@ -71,14 +69,6 @@ class TestAsync(unittest.TestCase):
         thing = NoIOErrorAfterCount(5)
         retrying = AsyncRetrying()
         await retrying(_async_function, thing)
-        assert thing.counter == thing.count
-
-    @asynctest
-    async def test_retry_using_async_retying_legacy_method(self):
-        thing = NoIOErrorAfterCount(5)
-        retrying = AsyncRetrying()
-        with pytest.warns(DeprecationWarning):
-            await retrying.call(_async_function, thing)
         assert thing.counter == thing.count
 
     @asynctest

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -1093,9 +1093,6 @@ class TestBeforeAfterAttempts(unittest.TestCase):
     def test_before_sleep_log_raises(self):
         self._before_sleep_log_raises(lambda x: x)
 
-    def test_before_sleep_log_raises_deprecated_call(self):
-        self._before_sleep_log_raises(lambda x: x.call)
-
     def test_before_sleep_log_raises_with_exc_info(self):
         thing = NoIOErrorAfterCount(2)
         logger = logging.getLogger(self.id())
@@ -1406,15 +1403,6 @@ class TestInvokeAsCallable:
         assert f.calls == [1, 2]
 
 
-class TestInvokeViaLegacyCallMethod(TestInvokeAsCallable):
-    """Retrying.call() method should work the same as Retrying.__call__()."""
-
-    @staticmethod
-    def invoke(retry, f):
-        with reports_deprecation_warning():
-            return retry.call(f)
-
-
 class TestRetryException(unittest.TestCase):
     def test_retry_error_is_pickleable(self):
         import pickle
@@ -1491,12 +1479,6 @@ class TestMockingSleep:
         sleep = MockSleep()
         monkeypatch.setattr(tenacity.nap.time, "sleep", sleep)
         yield sleep
-
-    def test_call(self, mock_sleep):
-        retrying = Retrying(**self.RETRY_ARGS)
-        with pytest.raises(RetryError):
-            retrying.call(self._fail)
-        assert mock_sleep.call_count == 4
 
     def test_decorated(self, mock_sleep):
         with pytest.raises(RetryError):


### PR DESCRIPTION
* `BaseRetrying.call` was long time deprecated and produced `DeprecationWarning`
* `BaseRetrying.fn` was noted as deprecated