### PR TITLE
Drop `py2` tag from the wheel name

### DIFF
--- a/releasenotes/notes/pr320-py3-only-wheel-tag.yaml
+++ b/releasenotes/notes/pr320-py3-only-wheel-tag.yaml
@@ -1,0 +1,5 @@
+---
+other: >-
+  Corrected the PyPI-published wheel tag to match the
+  metadata saying that the release is Python 3 only.
+...

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,9 +37,6 @@ doc =
     sphinx
     tornado>=4.5
 
-[wheel]
-universal = 1
-
 [tool:pytest]
 filterwarnings =
     # Show any DeprecationWarnings once


### PR DESCRIPTION
Having `>=3.6` in the metadata but still saying that it's py2-compatible in the file name is wrong. This change only keeps the `py3` tag.