### PR TITLE
Add dynamic configuration for stop & wait conditions

### DIFF
--- a/releasenotes/notes/dynamic-configuration-75ab1a482dd2e5b7.yaml
+++ b/releasenotes/notes/dynamic-configuration-75ab1a482dd2e5b7.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Add the ability to dynamically configure the stop and wait conditions

--- a/tenacity/_utils.py
+++ b/tenacity/_utils.py
@@ -66,3 +66,11 @@ def get_callback_name(cb: typing.Callable[..., typing.Any]) -> str:
         except AttributeError:
             pass
         return ".".join(segments)
+
+
+def call_if_callable(maybe_callable, *args, **kwargs):
+    """Calls the passed argument if possible, otherwise return it as is"""
+    if isinstance(maybe_callable, typing.Callable):
+        return maybe_callable(*args, **kwargs)
+    else:
+        return maybe_callable


### PR DESCRIPTION
This PR adds the ability to configure `@retry` based on the attributes of a class instance

Simplified use case:
 ```py
class Service:
    def __init__(self, tries):
        self.tries = tries

    @retry(
        retry=retry_if_exception_type(IOError),
        stop=stop_after_attempts(attempts=from_attr("tries")),
    )
    def call_other_service(self):
        ...


def load_config_from_file_system():
    ...


def main():
    config = load_config_from_file_system()
    serivice = Service(config.service.retry_attempts)
    serivice.call_other_service()
```