### PR TITLE
Rickroll a function name in one of the examples

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -95,7 +95,7 @@ an exception is raised.
 .. testcode::
 
     @retry
-    def never_give_up_never_surrender():
+    def never_gonna_give_you_up():
         print("Retry forever ignoring Exceptions, don't wait between retries")
         raise Exception
 


### PR DESCRIPTION
Half-seriously, use a slightly less appropriate function name in one of the example.

(I’m okay if this is left unmerged 🙂)