### PR TITLE
Add a "test" extra

### DIFF
--- a/releasenotes/notes/add-test-extra-55e869261b03e56d.yaml
+++ b/releasenotes/notes/add-test-extra-55e869261b03e56d.yaml
@@ -1,0 +1,3 @@
+---
+other:
+  - Add a \"test\" extra

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,10 @@ tenacity = py.typed
 doc =
     reno
     sphinx
+test =
+    pytest
     tornado>=4.5
+    typeguard
 
 [tool:pytest]
 filterwarnings =

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,8 @@ skip_missing_interpreters = True
 usedevelop = True
 sitepackages = False
 deps =
+    .[test]
     .[doc]
-    pytest
-    typeguard
 commands =
     py3{7,8,9,10,11},pypy3: pytest {posargs}
     py3{7,8,9,10,11},pypy3: sphinx-build -a -E -W -b doctest doc/source doc/build


### PR DESCRIPTION
Similar to the existing doc extra, specify a test extra with the relevant dependencies.  Since tornado is needed for the tests, move it from doc to test.  This will help distributions that package tenacity to gather the test dependencies without the doc dependencies.