### PR TITLE
Add retrying shim

### DIFF
--- a/retrying/__init__.py
+++ b/retrying/__init__.py
@@ -1,2 +1,1 @@
-# flake8: noqa
-from tenacity import retry
+from tenacity import retry # noqa

--- a/retrying/__init__.py
+++ b/retrying/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa
+from tenacity import retry

--- a/retrying/__init__.py
+++ b/retrying/__init__.py
@@ -1,1 +1,4 @@
-from tenacity import retry # noqa
+from tenacity import retry
+
+
+__all__ = ["retry", ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,9 @@ classifier =
 [options]
 install_requires =
 python_requires = >=3.6
-packages = tenacity
+packages =
+  tenacity
+  retrying
 
 [options.packages.find]
 exclude = tests

--- a/tests/test_retrying.py
+++ b/tests/test_retrying.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+def test_retrying():
+    try:
+        from retrying import retry
+    except ImportError:
+        assert False, "Failed to import retrying"


### PR DESCRIPTION
Introduces a shim that should enable drop-in replacement for the unmaintained https://github.com/rholder/retrying project.

Path towards fix for:
https://github.com/jd/tenacity/issues/356

An alternative approach might be to claim the name on PyPI and then publish a dummy package (with a breaking version number) with the shim. Over time you could standardise on one name or the other and log warnings and eventually fail (with another breaking version number).