### PR TITLE
Clarify the effect of `reraise=True`

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -251,8 +251,12 @@ exception:
 Error Handling
 ~~~~~~~~~~~~~~
 
-While callables that "timeout" retrying raise a `RetryError` by default,
-we can reraise the last attempt's exception if needed:
+Normally when your function fails its final time (and will not be retried again based on your settings),
+a `RetryError` is raised. The exception your code encountered will be shown somewhere in the *middle*
+of the stack trace.
+
+If you would rather see the exception your code encountered at the *end* of the stack trace (where it
+is most visible), you can set `reraise=True`.
 
 .. testcode::
 

--- a/releasenotes/notes/clarify-reraise-option-6829667eacf4f599.yaml
+++ b/releasenotes/notes/clarify-reraise-option-6829667eacf4f599.yaml
@@ -1,0 +1,3 @@
+---
+prelude: >
+    Clarify usage of `reraise` keyword argument


### PR DESCRIPTION
So happy to finally discover the `reraise=True` keyword argument.

This pull request aims to clarify what that argument does and convince more people to use it. 