### PR TITLE
fix(typing): make explicit what we re-export from root module

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -515,3 +515,67 @@ from tenacity._asyncio import AsyncRetrying  # noqa:E402,I100
 
 if tornado:
     from tenacity.tornadoweb import TornadoRetrying
+
+
+__all__ = [
+    "retry_base",
+    "retry_all",
+    "retry_always",
+    "retry_any",
+    "retry_if_exception",
+    "retry_if_exception_type",
+    "retry_if_exception_cause_type",
+    "retry_if_not_exception_type",
+    "retry_if_not_result",
+    "retry_if_result",
+    "retry_never",
+    "retry_unless_exception_type",
+    "retry_if_exception_message",
+    "retry_if_not_exception_message",
+    "sleep",
+    "sleep_using_event",
+    "stop_after_attempt",
+    "stop_after_delay",
+    "stop_all",
+    "stop_any",
+    "stop_never",
+    "stop_when_event_set",
+    "wait_chain",
+    "wait_combine",
+    "wait_exponential",
+    "wait_fixed",
+    "wait_incrementing",
+    "wait_none",
+    "wait_random",
+    "wait_random_exponential",
+    "wait_random_exponential as wait_full_jitter",
+    "wait_exponential_jitter",
+    "before_log",
+    "before_nothing",
+    "after_log",
+    "after_nothing",
+    "before_sleep_log",
+    "before_sleep_nothing",
+    "WrappedFn",
+    "retry" "TryAgain",
+    "NO_RESULT",
+    "DoAttempt",
+    "DoSleep",
+    "BaseAction",
+    "RetryAction",
+    "RetryError",
+    "AttemptManager",
+    "BaseRetrying",
+    "Future",
+    "RetryCallState",
+    "AsyncRetrying",
+    "TornadoRetrying",
+]
+
+if t.TYPE_CHECKING:
+    __all__.extend(
+        [
+            "wait_base",
+            "stop_base",
+        ]
+    )


### PR DESCRIPTION
Mypy ignores re-exported modules/classes/functions/... as it can known
which object you want to re-export which you don't want. In tenacity we
re-export submodule class/function on purpose, so we need to list them
explicitly.