### PR TITLE
fix(mypy): add missing typing

### DIFF
--- a/tenacity/retry.py
+++ b/tenacity/retry.py
@@ -36,6 +36,9 @@ class retry_base(abc.ABC):
         return retry_any(self, other)
 
 
+RetryBaseT = typing.Union[retry_base, typing.Callable[["RetryCallState"], bool]]
+
+
 class _retry_never(retry_base):
     """Retry strategy that never rejects any result."""
 

--- a/tenacity/stop.py
+++ b/tenacity/stop.py
@@ -38,6 +38,9 @@ class stop_base(abc.ABC):
         return stop_any(self, other)
 
 
+StopBaseT = typing.Union[stop_base, typing.Callable[["RetryCallState"], bool]]
+
+
 class stop_any(stop_base):
     """Stop if any of the stop condition is valid."""
 

--- a/tenacity/wait.py
+++ b/tenacity/wait.py
@@ -41,6 +41,9 @@ class wait_base(abc.ABC):
         return self.__add__(other)
 
 
+WaitBaseT = typing.Union[wait_base, typing.Callable[["RetryCallState"], bool]]
+
+
 class wait_fixed(wait_base):
     """Wait strategy that waits a fixed amount of time between each retry."""
 


### PR DESCRIPTION
Runtime callbacks for retry/stop/wait allow to pass a function or a
class that inherit from retry_base/wait_base/stop_base.

This fixes the typing when a function is used.

Fixes #324