### PR TITLE
fix: remove __iter__ from AsyncRetring

### DIFF
--- a/releasenotes/notes/no-async-iter-6132a42e52348a75.yaml
+++ b/releasenotes/notes/no-async-iter-6132a42e52348a75.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    `AsyncRetrying` was erroneously implementing `__iter__()`, making tenacity
+    retrying mechanism working but in a synchronous fashion and not waiting as
+    expected. This interface has been removed, `__aiter__()` should be used
+    instead.

--- a/tenacity/_asyncio.py
+++ b/tenacity/_asyncio.py
@@ -62,6 +62,9 @@ class AsyncRetrying(BaseRetrying):
             else:
                 return do  # type: ignore[no-any-return]
 
+    def __iter__(self) -> typing.Generator[AttemptManager, None, None]:
+        raise TypeError("AsyncRetrying object is not iterable")
+
     def __aiter__(self) -> "AsyncRetrying":
         self.begin()
         self._retry_state = RetryCallState(self, fn=None, args=(), kwargs={})

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -18,6 +18,8 @@ import inspect
 import unittest
 from functools import wraps
 
+import pytest
+
 from tenacity import AsyncRetrying, RetryError
 from tenacity import _asyncio as tasyncio
 from tenacity import retry, retry_if_result, stop_after_attempt
@@ -169,6 +171,14 @@ class TestContextManager(unittest.TestCase):
         result = await test()
 
         self.assertEqual(3, result)
+
+    @asynctest
+    async def test_async_retying_iterator(self):
+        thing = NoIOErrorAfterCount(5)
+        with pytest.raises(TypeError):
+            for attempts in AsyncRetrying():
+                with attempts:
+                    await _async_function(thing)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This method doesn't make sense for AsyncRetrying. And it's even more
vicious as:

```
for attempts in AsyncRetrying():
    with attempts:
        await do_for_a_while()
```

will work, but sleep(XXX) coroutine will never be awaited and the call is
retried instantly.

This change removes the __iter__ method from AsyncRetrying.