### PR TITLE
chore(typing): improve typing of WrappedFn

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
 
 [testenv:mypy]
 deps =
-    mypy
+    mypy>=1.0.0
 commands =
     mypy tenacity
 


### PR DESCRIPTION
This change improves the typing of WrappedFn.
It makes explictly the two signatures of tenacity.retry() with overload.

This avoids mypy thinking the return type is `<nothing>`