### PR TITLE
Fix tests for typeguard 3.x

### DIFF
--- a/releasenotes/notes/Fix-tests-for-typeguard-3.x-6eebfea546b6207e.yaml
+++ b/releasenotes/notes/Fix-tests-for-typeguard-3.x-6eebfea546b6207e.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - "Fixes test failures with typeguard 3.x"

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -1542,10 +1542,10 @@ class TestRetryTyping(unittest.TestCase):
         with_constructor_result = with_raw(1)
 
         # These raise TypeError exceptions if they fail
-        check_type("with_raw", with_raw, typing.Callable[[int], str])
-        check_type("with_raw_result", with_raw_result, str)
-        check_type("with_constructor", with_constructor, typing.Callable[[int], str])
-        check_type("with_constructor_result", with_constructor_result, str)
+        check_type(with_raw, typing.Callable[[int], str])
+        check_type(with_raw_result, str)
+        check_type(with_constructor, typing.Callable[[int], str])
+        check_type(with_constructor_result, str)
 
 
 @contextmanager


### PR DESCRIPTION
typeguard 3.x introduced an incompatible change to `check_type()`'s signature.

Fixes #395