### PR TITLE
Add support for async sleep functions in tenacity.retry annotation.

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -499,7 +499,7 @@ def retry(func: WrappedFn) -> WrappedFn:
 
 @t.overload
 def retry(
-    sleep: t.Callable[[t.Union[int, float]], None] = sleep,
+    sleep: t.Callable[[t.Union[int, float]], t.Optional[t.Awaitable[None]]] = sleep,
     stop: "StopBaseT" = stop_never,
     wait: "WaitBaseT" = wait_none(),
     retry: "RetryBaseT" = retry_if_exception_type(),


### PR DESCRIPTION
Fixes https://github.com/jd/tenacity/issues/399

Since tests aren't typechecked I didn't add a test for this, although if you want I could open another PR with tox modifications and `# mypy: disable-error-codes= I added to check it locally.