### PR TITLE
Typecheck tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ target-version = ["py37", "py38", "py39", "py310", "py311"]
 
 [tool.mypy]
 strict = true
-files = ["tenacity"]
+files = ["tenacity", "tests"]
 show_error_codes = true
 
 [[tool.mypy.overrides]]

--- a/tests/test_after.py
+++ b/tests/test_after.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="no-untyped-def,no-untyped-call"
 import logging
 import random
 import unittest.mock

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -1,3 +1,4 @@
+# mypy: disable_error_code="no-untyped-def,no-untyped-call,attr-defined,arg-type,no-any-return,list-item,var-annotated,import,call-overload"
 # Copyright 2016–2021 Julien Danjou
 # Copyright 2016 Joshua Harlow
 # Copyright 2013 Ray Holder

--- a/tests/test_tornado.py
+++ b/tests/test_tornado.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="no-untyped-def,no-untyped-call"
 # coding: utf-8
 # Copyright 2017 Elisey Zanko
 #
@@ -38,7 +39,7 @@ def _retryable_coroutine_with_2_attempts(thing):
     thing.go()
 
 
-class TestTornado(testing.AsyncTestCase):
+class TestTornado(testing.AsyncTestCase):  # type: ignore[misc]
     @testing.gen_test
     def test_retry(self):
         assert gen.is_coroutine_function(_retryable_coroutine)

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps = flake8
        flake8-docstrings
        flake8-rst-docstrings
        flake8-logging-format
-commands = flake8
+commands = flake8 {posargs}
 
 [testenv:black]
 deps =
@@ -34,8 +34,9 @@ commands =
 [testenv:mypy]
 deps =
     mypy>=1.0.0
+    pytest # for stubs
 commands =
-    mypy tenacity
+    mypy {posargs}
 
 [testenv:black-ci]
 deps =


### PR DESCRIPTION
Runs the `tests/` folder against mypy as well. Which I've found to be a great way to catch annotation errors in typechecked code in my projects, but I didn't bother trying to typehint everything and just threw up enough ignore/disables until mypy got silent.

Forked on top of #400, adding a test for it.