### PR TITLE
Preserve function default and kwdefault through retry decorator

### DIFF
--- a/releasenotes/notes/some-slug-for-preserve-defaults-86682846dfa18005.yaml
+++ b/releasenotes/notes/some-slug-for-preserve-defaults-86682846dfa18005.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Preserve __defaults__ and __kwdefaults__ through retry decorator

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -284,7 +284,7 @@ class BaseRetrying(ABC):
         :param f: A function to wraps for retrying.
         """
 
-        @functools.wraps(f)
+        @functools.wraps(f, functools.WRAPPER_ASSIGNMENTS + ("__defaults__", "__kwdefaults__"))
         def wrapped_f(*args: t.Any, **kw: t.Any) -> t.Any:
             return self(f, *args, **kw)
 

--- a/tenacity/_asyncio.py
+++ b/tenacity/_asyncio.py
@@ -83,7 +83,7 @@ class AsyncRetrying(BaseRetrying):
         fn = super().wraps(fn)
         # Ensure wrapper is recognized as a coroutine function.
 
-        @functools.wraps(fn)
+        @functools.wraps(fn, functools.WRAPPER_ASSIGNMENTS + ("__defaults__", "__kwdefaults__"))
         async def async_wrapped(*args: t.Any, **kwargs: t.Any) -> t.Any:
             return await fn(*args, **kwargs)
 

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -1054,6 +1054,20 @@ class TestDecoratorWrapper(unittest.TestCase):
         except NameError:
             pass
 
+    def test_retry_preserves_argument_defaults(self):
+        def function_with_defaults(a=1):
+            return a
+
+        def function_with_kwdefaults(*, a=1):
+            return a
+
+        retrying = Retrying(wait=tenacity.wait_fixed(0.01), stop=tenacity.stop_after_attempt(3))
+        wrapped_defaults_function = retrying.wraps(function_with_defaults)
+        wrapped_kwdefaults_function = retrying.wraps(function_with_kwdefaults)
+
+        self.assertEqual(function_with_defaults.__defaults__, wrapped_defaults_function.__defaults__)
+        self.assertEqual(function_with_kwdefaults.__kwdefaults__, wrapped_kwdefaults_function.__kwdefaults__)
+
     def test_defaults(self):
         self.assertTrue(_retryable_default(NoNameErrorAfterCount(5)))
         self.assertTrue(_retryable_default_f(NoNameErrorAfterCount(5)))


### PR DESCRIPTION
Hello, and thanks for the great package. I noticed that the `retry` decorator uses `functools.wraps`. By default, this means that `__defaults__` and `__kwdefaults__` will always be `None` on the wrapped function. In general this is reasonable behavior, since a wrapper could change these defaults. However, I believe the retry decorator does not, and thus should preserve these attributes. I've created a patch to change this, please let me know what you think :)