### PR TITLE
Add support for Python 3.12 and drop EOL 3.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,7 @@ name: Continuous Integration
 permissions: read-all
 
 on:
+  push:
   pull_request:
     branches:
       - main
@@ -34,16 +35,19 @@ jobs:
             tox: black-ci
           - python: "3.11"
             tox: mypy
+          - python: "3.12"
+            tox: py312
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v4.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Python 🔧
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4.7.0
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ matrix.python }}
+          allow-prereleases: true
 
       - name: Build 🔧 & Test 🔍
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python: "3.7"
-            tox: py37
           - python: "3.8"
             tox: py38
           - python: "3.9"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v4.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Python 🔧
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4.7.0
         with:
           python-version: 3.11
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   test:
+    if: github.repository_owner == 'jd'
     timeout-minutes: 20
     runs-on: ubuntu-20.04
     steps:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,6 @@
 queue_rules:
   - name: default
     conditions: &CheckRuns
-      - "check-success=test (3.7, py37)"
       - "check-success=test (3.8, py38)"
       - "check-success=test (3.9, py39)"
       - "check-success=test (3.10, py310)"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,6 +6,7 @@ queue_rules:
       - "check-success=test (3.9, py39)"
       - "check-success=test (3.10, py310)"
       - "check-success=test (3.11, py311)"
+      - "check-success=test (3.12, py312)"
       - "check-success=test (3.11, black-ci)"
       - "check-success=test (3.11, pep8)"
       - "check-success=test (3.11, mypy)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend="setuptools.build_meta"
 [tool.black]
 line-length = 120
 safe = true
-target-version = ["py37", "py38", "py39", "py310", "py311", "py312"]
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 
 [tool.mypy]
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend="setuptools.build_meta"
 [tool.black]
 line-length = 120
 safe = true
-target-version = ["py37", "py38", "py39", "py310", "py311"]
+target-version = ["py37", "py38", "py39", "py310", "py311", "py312"]
 
 [tool.mypy]
 strict = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifier =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Utilities
 
 [options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifier =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -23,7 +22,7 @@ classifier =
 
 [options]
 install_requires =
-python_requires = >=3.7
+python_requires = >=3.8
 packages = tenacity
 
 [options.packages.find]

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -1,5 +1,4 @@
 # mypy: disable-error-code="no-untyped-def,no-untyped-call"
-# coding: utf-8
 # Copyright 2016 Étienne Bersac
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -657,7 +657,7 @@ class NoIOErrorAfterCount:
         """
         if self.counter < self.count:
             self.counter += 1
-            raise IOError("Hi there, I'm an IOError")
+            raise OSError("Hi there, I'm an IOError")
         return True
 
 
@@ -699,7 +699,7 @@ class NoNameErrorCauseAfterCount:
             try:
                 self.go2()
             except NameError as e:
-                raise IOError() from e
+                raise OSError() from e
 
         return True
 
@@ -712,7 +712,7 @@ class NoIOErrorCauseAfterCount:
         self.count = count
 
     def go2(self):
-        raise IOError("Hi there, I'm an IOError")
+        raise OSError("Hi there, I'm an IOError")
 
     def go(self):
         """Raise a NameError with an IOError as cause until after count threshold has been crossed.
@@ -723,7 +723,7 @@ class NoIOErrorCauseAfterCount:
             self.counter += 1
             try:
                 self.go2()
-            except IOError as e:
+            except OSError as e:
                 raise NameError() from e
 
         return True
@@ -764,7 +764,7 @@ class IOErrorUntilCount:
         if self.counter < self.count:
             self.counter += 1
             return True
-        raise IOError("Hi there, I'm an IOError")
+        raise OSError("Hi there, I'm an IOError")
 
 
 class CustomError(Exception):
@@ -947,7 +947,7 @@ class TestDecoratorWrapper(unittest.TestCase):
         try:
             _retryable_test_with_stop(NoIOErrorAfterCount(5))
             self.fail("Expected IOError")
-        except IOError as re:
+        except OSError as re:
             self.assertTrue(isinstance(re, IOError))
             print(re)
 
@@ -976,7 +976,7 @@ class TestDecoratorWrapper(unittest.TestCase):
         try:
             _retryable_test_if_not_exception_type_io(NoIOErrorAfterCount(5))
             self.fail("Expected IOError")
-        except IOError as err:
+        except OSError as err:
             self.assertTrue(isinstance(err, IOError))
             print(err)
 
@@ -1114,7 +1114,7 @@ class TestRetryWith:
 
     def test_retry_error_callback_should_be_preserved(self):
         def return_text(retry_state):
-            return "Calling %s keeps raising errors after %s attempts" % (
+            return "Calling {} keeps raising errors after {} attempts".format(
                 retry_state.fn.__name__,
                 retry_state.attempt_number,
             )

--- a/tests/test_tornado.py
+++ b/tests/test_tornado.py
@@ -1,5 +1,4 @@
 # mypy: disable-error-code="no-untyped-def,no-untyped-call"
-# coding: utf-8
 # Copyright 2017 Elisey Zanko
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{7,8,9,10,11,12}, pep8, pypy3
+envlist = py3{8,9,10,11,12}, pep8, pypy3
 skip_missing_interpreters = True
 
 [testenv]
@@ -9,9 +9,9 @@ deps =
     .[test]
     .[doc]
 commands =
-    py3{7,8,9,10,11,12},pypy3: pytest {posargs}
-    py3{7,8,9,10,11,12},pypy3: sphinx-build -a -E -W -b doctest doc/source doc/build
-    py3{7,8,9,10,11,12},pypy3: sphinx-build -a -E -W -b html doc/source doc/build
+    py3{8,9,10,11,12},pypy3: pytest {posargs}
+    py3{8,9,10,11,12},pypy3: sphinx-build -a -E -W -b doctest doc/source doc/build
+    py3{8,9,10,11,12},pypy3: sphinx-build -a -E -W -b html doc/source doc/build
 
 [testenv:pep8]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{7,8,9,10,11}, pep8, pypy3
+envlist = py3{7,8,9,10,11,12}, pep8, pypy3
 skip_missing_interpreters = True
 
 [testenv]
@@ -9,9 +9,9 @@ deps =
     .[test]
     .[doc]
 commands =
-    py3{7,8,9,10,11},pypy3: pytest {posargs}
-    py3{7,8,9,10,11},pypy3: sphinx-build -a -E -W -b doctest doc/source doc/build
-    py3{7,8,9,10,11},pypy3: sphinx-build -a -E -W -b html doc/source doc/build
+    py3{7,8,9,10,11,12},pypy3: pytest {posargs}
+    py3{7,8,9,10,11,12},pypy3: sphinx-build -a -E -W -b doctest doc/source doc/build
+    py3{7,8,9,10,11,12},pypy3: sphinx-build -a -E -W -b html doc/source doc/build
 
 [testenv:pep8]
 basepython = python3


### PR DESCRIPTION
The [second Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0rc2-final-release-candidate-released/33105/5?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

Python 3.12.0 final is due out in two weeks: [2023-10-02](https://peps.python.org/pep-0693/).

See also https://dev.to/hugovk/help-test-python-312-beta-1508/

---

Python 3.7 is EOL and no longer receiving security updates (or any updates) from the core Python team.

| version |  released  |    eol     |
|:--------|:----------:|:----------:|
| 3.11    | 2022-10-24 | 2027-10-24 |
| 3.10    | 2021-10-04 | 2026-10-04 |
| 3.9     | 2020-10-05 | 2025-10-05 |
| 3.8     | 2019-10-14 | 2024-10-14 |
| 3.7     | 2018-06-26 | 2023-06-27 |

https://devguide.python.org/versions/

Also, only deploy for upstream, it fails for forks.
