### PR TITLE
Add ability to inspect upcoming sleep in `stop` funcs, and add `stop_before_delay`

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -124,6 +124,16 @@ retrying stuff.
         print("Stopping after 10 seconds")
         raise Exception
 
+If you're on a tight deadline, and exceeding your delay time isn't ok, 
+then you can give up on retries one attempt before you would exceed the delay. 
+
+.. testcode::
+
+    @retry(stop=stop_before_delay(10))
+    def stop_before_10_s():
+        print("Stopping 1 attempt before 10 seconds")
+        raise Exception
+
 You can combine several stop conditions by using the `|` operator:
 
 .. testcode::

--- a/releasenotes/notes/add-stop-before-delay-a775f88ac872c923.yaml
+++ b/releasenotes/notes/add-stop-before-delay-a775f88ac872c923.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Added a new stop function: stop_before_delay, which will stop execution
+    if the next sleep time would cause overall delay to exceed the specified delay. 
+    Useful for use cases where you have some upper bound on retry times that you must
+    not exceed, so returning before that timeout is preferable than returning after that timeout.

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -50,6 +50,7 @@ from .nap import sleep_using_event  # noqa
 # Import all built-in stop strategies for easier usage.
 from .stop import stop_after_attempt  # noqa
 from .stop import stop_after_delay  # noqa
+from .stop import stop_before_delay  # noqa
 from .stop import stop_all  # noqa
 from .stop import stop_any  # noqa
 from .stop import stop_never  # noqa
@@ -316,6 +317,13 @@ class BaseRetrying(ABC):
         if self.after is not None:
             self.after(retry_state)
 
+        if self.wait:
+            sleep = self.wait(retry_state)
+        else:
+            sleep = 0.0
+
+        retry_state.upcoming_sleep = sleep
+
         self.statistics["delay_since_first_attempt"] = retry_state.seconds_since_start
         if self.stop(retry_state):
             if self.retry_error_callback:
@@ -325,10 +333,6 @@ class BaseRetrying(ABC):
                 raise retry_exc.reraise()
             raise retry_exc from fut.exception()
 
-        if self.wait:
-            sleep = self.wait(retry_state)
-        else:
-            sleep = 0.0
         retry_state.next_action = RetryAction(sleep)
         retry_state.idle_for += sleep
         self.statistics["idle_for"] += sleep
@@ -568,6 +572,7 @@ __all__ = [
     "sleep_using_event",
     "stop_after_attempt",
     "stop_after_delay",
+    "stop_before_delay",
     "stop_all",
     "stop_any",
     "stop_never",

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -455,6 +455,8 @@ class RetryCallState:
         self.idle_for: float = 0.0
         #: Next action as decided by the retry manager
         self.next_action: t.Optional[RetryAction] = None
+        #: Next sleep time as decided by the retry manager.
+        self.upcoming_sleep: float = 0.0
 
     @property
     def seconds_since_start(self) -> t.Optional[float]:

--- a/tenacity/stop.py
+++ b/tenacity/stop.py
@@ -97,7 +97,7 @@ class stop_after_delay(stop_base):
 
     Note: `max_delay` will be exceeded, so when used with a `wait`, the actual total delay will be greater
     than `max_delay` by some of the final sleep period before `max_delay` is exceeded.
-    
+
     If you need stricter timing with waits, consider `stop_before_delay` instead.
     """
 
@@ -108,6 +108,7 @@ class stop_after_delay(stop_base):
         if retry_state.seconds_since_start is None:
             raise RuntimeError("__call__() called but seconds_since_start is not set")
         return retry_state.seconds_since_start >= self.max_delay
+
 
 class stop_before_delay(stop_base):
     """

--- a/tenacity/stop.py
+++ b/tenacity/stop.py
@@ -101,3 +101,14 @@ class stop_after_delay(stop_base):
         if retry_state.seconds_since_start is None:
             raise RuntimeError("__call__() called but seconds_since_start is not set")
         return retry_state.seconds_since_start >= self.max_delay
+
+class stop_before_delay(stop_base):
+    """Stop right before the next attempt would take place after the time from the first attempt >= limit."""
+
+    def __init__(self, max_delay: _utils.time_unit_type) -> None:
+        self.max_delay = _utils.to_seconds(max_delay)
+
+    def __call__(self, retry_state: "RetryCallState") -> bool:
+        if retry_state.seconds_since_start is None:
+            raise RuntimeError("__call__() called but seconds_since_start is not set")
+        return retry_state.seconds_since_start + retry_state.upcoming_sleep >= self.max_delay

--- a/tenacity/stop.py
+++ b/tenacity/stop.py
@@ -92,7 +92,14 @@ class stop_after_attempt(stop_base):
 
 
 class stop_after_delay(stop_base):
-    """Stop when the time from the first attempt >= limit."""
+    """
+    Stop when the time from the first attempt >= limit.
+
+    Note: `max_delay` will be exceeded, so when used with a `wait`, the actual total delay will be greater
+    than `max_delay` by some of the final sleep period before `max_delay` is exceeded.
+    
+    If you need stricter timing with waits, consider `stop_before_delay` instead.
+    """
 
     def __init__(self, max_delay: _utils.time_unit_type) -> None:
         self.max_delay = _utils.to_seconds(max_delay)
@@ -103,7 +110,12 @@ class stop_after_delay(stop_base):
         return retry_state.seconds_since_start >= self.max_delay
 
 class stop_before_delay(stop_base):
-    """Stop right before the next attempt would take place after the time from the first attempt >= limit."""
+    """
+    Stop right before the next attempt would take place after the time from the first attempt >= limit.
+
+    Most useful when you are using with a `wait` function like wait_random_exponential, but need to make
+    sure that the max_delay is not exceeded.
+    """
 
     def __init__(self, max_delay: _utils.time_unit_type) -> None:
         self.max_delay = _utils.to_seconds(max_delay)

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -174,6 +174,11 @@ class TestStopConditions(unittest.TestCase):
                 self.assertTrue(r.stop(make_retry_state(2, 1, upcoming_sleep=0.001)))
                 self.assertTrue(r.stop(make_retry_state(2, 1, upcoming_sleep=1)))
 
+                # It should act the same as stop_after_delay if upcoming sleep is 0
+                self.assertFalse(r.stop(make_retry_state(2, 0.999, upcoming_sleep=0)))
+                self.assertTrue(r.stop(make_retry_state(2, 1, upcoming_sleep=0)))
+                self.assertTrue(r.stop(make_retry_state(2, 1.001, upcoming_sleep=0)))
+
     def test_legacy_explicit_stop_type(self):
         Retrying(stop="stop_after_attempt")
 


### PR DESCRIPTION
This seeks to solve a specific problem: if using a wait function like `wait_exponential` or `wait_random_exponential`, along with `stop_after_delay`, the overall time spent retrying is >= `max_delay`.

However, in situations where you have a strict deadline and you can't block for longer than `max_delay`, it may be preferable to abort 1 retry attempt early so that you don't exceed that deadline.

This PR seeks to achieve that behavior by implementing `stop_before_delay`, which stops retries if the next attempt would take place after the `max_delay` time has elapsed, thereby ensuring that `max_delay` is never surpassed.

Examples of problem using exponential delays, and a 5 second deadline w/ `stop_after_delay`:

```py
In [5]: @retry(stop=stop_after_delay(5), wait=wait_exponential())
   ...: def stop_after_w_e():
   ...:     print(datetime.now())
   ...:     raise Exception

In [11]: stop_after_w_e()
2023-11-08 23:18:12.259584
2023-11-08 23:18:13.261515
2023-11-08 23:18:15.262064
2023-11-08 23:18:19.263860
---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)

```

Note how the execution timestamp is 7 seconds after the initial one, despite the 5 second `max_delay`.

```py
In [6]: @retry(stop=stop_after_delay(5), wait=wait_random_exponential())
   ...: def stop_after_w_r_e():
   ...:     print(datetime.now())
   ...:     raise Exception
   ...:

In [12]: stop_after_w_r_e()
2023-11-08 23:19:02.682304
2023-11-08 23:19:02.991432
2023-11-08 23:19:04.510066
2023-11-08 23:19:07.398501
2023-11-08 23:19:14.172982
---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)
```
Note the same thing w/ random exponential backoff. In this case the final attempt is made 11.49 seconds after the first one, despite a 5 second `max_delay`. That's over 2x the amount of time spent blocking on retries than our strict deadline allows! 

This situation with random exponential backoff is the one that I'm interested in improving upon for my own use case (avoiding thundering herds during connection retries from many parallel clients). This extra time spent waiting after `max_delay` can be quite long with higher amounts exponential backoff. eg. a supposedly 30s `max_delay` that actually blocks for over 1 minute can cause some confusion.

With `stop_before`, the `max_delay` is never exceeded:
```py
In [12]: @retry(stop=stop_before_delay(5), wait=wait_exponential())
    ...: def stop_before_w_e():
    ...:     print(datetime.now())
    ...:     raise Exception

In [13]: stop_before_w_e()
2023-11-08 23:21:56.437116
2023-11-08 23:21:57.439288
2023-11-08 23:21:59.441351
---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)
```

Total elapsed time is < 5 seconds (3 seconds).

```py
In [14]: @retry(stop=stop_before_delay(5), wait=wait_random_exponential())
    ...: def stop_before_w_r_e():
    ...:     print(datetime.now())
    ...:     raise Exception

In [15]: stop_before_w_r_e()
2023-11-08 23:23:13.550395
2023-11-08 23:23:14.344831
2023-11-08 23:23:15.533050
2023-11-08 23:23:17.907447
---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)
```

Total elapsed time is < 5 seconds (4.35).