### PR TITLE
typing: update version compare to support pyright/pylance

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -391,7 +391,7 @@ class Retrying(BaseRetrying):
                 return do  # type: ignore[no-any-return]
 
 
-if sys.version_info[1] >= 9:
+if sys.version_info >= (3, 9):
     FutureGenericT = futures.Future[t.Any]
 else:
     FutureGenericT = futures.Future


### PR DESCRIPTION
The current version comparison works with mypy but pyright doesn't handle it.

Comparing against minor and major version allows it to work with pyright.

related: https://github.com/microsoft/pyright/issues/6639