### PR TITLE
Respects `min` argument for `wait_random_exponential`

### DIFF
--- a/releasenotes/notes/wait-random-exponential-min-2a4b7eed9f002436.yaml
+++ b/releasenotes/notes/wait-random-exponential-min-2a4b7eed9f002436.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Respects `min` arg for `wait_random_exponential`

--- a/tenacity/wait.py
+++ b/tenacity/wait.py
@@ -191,7 +191,7 @@ class wait_random_exponential(wait_exponential):
 
     def __call__(self, retry_state: "RetryCallState") -> float:
         high = super().__call__(retry_state=retry_state)
-        return random.uniform(0, high)
+        return random.uniform(self.min, high)
 
 
 class wait_exponential_jitter(wait_base):

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -417,17 +417,17 @@ class TestWaitConditions(unittest.TestCase):
             self._assert_inclusive_range(fn(make_retry_state(8, 0)), 0, 60.0)
             self._assert_inclusive_range(fn(make_retry_state(9, 0)), 0, 60.0)
 
-        # max
-        max = 5
+        # max wait
+        max_wait = 5
         fn = tenacity.wait_random_exponential(10, max)
         for _ in range(1000):
-            self._assert_inclusive_range(fn(make_retry_state(1, 0)), 0.00, max)
+            self._assert_inclusive_range(fn(make_retry_state(1, 0)), 0.00, max_wait)
 
-        # min
-        min = 5
+        # min wait
+        min_wait = 5
         fn = tenacity.wait_random_exponential(min=min)
         for _ in range(1000):
-            self._assert_inclusive_range(fn(make_retry_state(1, 0)), min, 5)
+            self._assert_inclusive_range(fn(make_retry_state(1, 0)), min_wait, 5)
 
         # Default arguments exist
         fn = tenacity.wait_random_exponential()

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -417,9 +417,17 @@ class TestWaitConditions(unittest.TestCase):
             self._assert_inclusive_range(fn(make_retry_state(8, 0)), 0, 60.0)
             self._assert_inclusive_range(fn(make_retry_state(9, 0)), 0, 60.0)
 
-        fn = tenacity.wait_random_exponential(10, 5)
+        # max
+        max = 5
+        fn = tenacity.wait_random_exponential(10, max)
         for _ in range(1000):
-            self._assert_inclusive_range(fn(make_retry_state(1, 0)), 0.00, 5.00)
+            self._assert_inclusive_range(fn(make_retry_state(1, 0)), 0.00, max)
+
+        # min
+        min = 1
+        fn = tenacity.wait_random_exponential(0.5, min=min)
+        for _ in range(1000):
+            self._assert_inclusive_range(fn(make_retry_state(1, 0)), min, 1)
 
         # Default arguments exist
         fn = tenacity.wait_random_exponential()

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -424,10 +424,10 @@ class TestWaitConditions(unittest.TestCase):
             self._assert_inclusive_range(fn(make_retry_state(1, 0)), 0.00, max)
 
         # min
-        min = 1
-        fn = tenacity.wait_random_exponential(0.5, min=min)
+        min = 5
+        fn = tenacity.wait_random_exponential(min=min)
         for _ in range(1000):
-            self._assert_inclusive_range(fn(make_retry_state(1, 0)), min, 1)
+            self._assert_inclusive_range(fn(make_retry_state(1, 0)), min, 5)
 
         # Default arguments exist
         fn = tenacity.wait_random_exponential()

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -435,13 +435,13 @@ class TestWaitConditions(unittest.TestCase):
 
         # max wait
         max_wait = 5
-        fn = tenacity.wait_random_exponential(10, max)
+        fn = tenacity.wait_random_exponential(10, max_wait)
         for _ in range(1000):
             self._assert_inclusive_range(fn(make_retry_state(1, 0)), 0.00, max_wait)
 
         # min wait
         min_wait = 5
-        fn = tenacity.wait_random_exponential(min=min)
+        fn = tenacity.wait_random_exponential(min=min_wait)
         for _ in range(1000):
             self._assert_inclusive_range(fn(make_retry_state(1, 0)), min_wait, 5)
 


### PR DESCRIPTION
# Summary

Respects `min` argument for `wait_random_exponential`
- currently, `min` argument only affects computing the `high` range of the uniform sampling
- `min` does not affect the `low` range of the uniform sampling, hence the sampled wait may be lower than `min` specified
- This PR fixes the issue, which I believe is unexpected

# Tests
```
pytest tests/test_tenacity.py::TestWaitConditions::test_wait_random_exponential
```