### PR TITLE
Incrementally build iter actions list

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -96,7 +96,12 @@ WrappedFnReturnT = t.TypeVar("WrappedFnReturnT")
 WrappedFn = t.TypeVar("WrappedFn", bound=t.Callable[..., t.Any])
 
 
-@dataclasses.dataclass(slots=True)
+dataclass_kwargs = {}
+if sys.version_info >= (3, 10):
+    dataclass_kwargs.update({"slots": True})
+
+
+@dataclasses.dataclass(**dataclass_kwargs)
 class IterState:
     actions: t.List[t.Callable[["RetryCallState"], t.Any]] = dataclasses.field(
         default_factory=list

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -98,7 +98,7 @@ WrappedFn = t.TypeVar("WrappedFn", bound=t.Callable[..., t.Any])
 
 @dataclasses.dataclass(slots=True)
 class IterState:
-    actions: list[t.Callable[["RetryCallState"], t.Any]] = dataclasses.field(
+    actions: t.List[t.Callable[["RetryCallState"], t.Any]] = dataclasses.field(
         default_factory=list
     )
     retry_run_result: bool = False

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -372,13 +372,17 @@ class BaseRetrying(ABC):
             self._add_action_func(lambda rs: DoAttempt())
             return
 
-        self.iter_state["is_explicit_retry"] = fut.failed and isinstance(fut.exception(), TryAgain)
+        self.iter_state["is_explicit_retry"] = fut.failed and isinstance(
+            fut.exception(), TryAgain
+        )
         if not self.iter_state["is_explicit_retry"]:
             self._add_action_func(self._run_retry)
         self._add_action_func(self._post_retry_check_actions)
 
     def _post_retry_check_actions(self, retry_state: "RetryCallState") -> None:
-        if not (self.iter_state["is_explicit_retry"] or self.iter_state["retry_run_result"]):
+        if not (
+            self.iter_state["is_explicit_retry"] or self.iter_state["retry_run_result"]
+        ):
             self._add_action_func(lambda rs: rs.outcome.result())
             return
 


### PR DESCRIPTION
First PR after breaking down https://github.com/jd/tenacity/pull/433
- Second PR https://github.com/hasier/tenacity/pull/1
- Third PR https://github.com/hasier/tenacity/pull/2

An attempt at [DRYing the `iter()` function](https://github.com/jd/tenacity/pull/363#pullrequestreview-1118442473) in order to support `async` callbacks.

The approach I have taken is to build a list of actions that `iter()` needs to go through, where each action is just a piece of the whole current logic, and each step can further extend the list of actions. 3 pieces have been taken out to redefine in specific Retrying implementations, i.e. `asyncio`. This way we can make sure we use coroutines for those calls, as well as dynamically wrapping each function as a coroutine, allowing for both sync and async strategies and callbacks.