### PR TITLE
Add a Dependabot config to autoupdate GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/releasenotes/notes/dependabot-for-github-actions-4d2464f3c0928463.yaml
+++ b/releasenotes/notes/dependabot-for-github-actions-4d2464f3c0928463.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    Add a Dependabot configuration submit PRs monthly (as needed)
+    to keep GitHub action versions updated.


### PR DESCRIPTION
This PR introduces a Dependabot configuration to auto-update GitHub action versions.

CI jobs are currently throwing deprecation warnings due to old versions of actions using Node 16 [[recent example](https://github.com/jd/tenacity/actions/runs/7798746570)]. If this PR merges, you can expect Dependabot to open a PR to update action versions as needed.