### PR TITLE
Add support for mocking sleep when retrying async functions

### DIFF
--- a/tenacity/_asyncio.py
+++ b/tenacity/_asyncio.py
@@ -18,13 +18,13 @@
 import functools
 import sys
 import typing as t
-from asyncio import sleep
 
 from tenacity import AttemptManager
 from tenacity import BaseRetrying
 from tenacity import DoAttempt
 from tenacity import DoSleep
 from tenacity import RetryCallState
+from tenacity.nap import async_sleep
 
 WrappedFnReturnT = t.TypeVar("WrappedFnReturnT")
 WrappedFn = t.TypeVar("WrappedFn", bound=t.Callable[..., t.Awaitable[t.Any]])
@@ -34,7 +34,7 @@ class AsyncRetrying(BaseRetrying):
     sleep: t.Callable[[float], t.Awaitable[t.Any]]
 
     def __init__(
-        self, sleep: t.Callable[[float], t.Awaitable[t.Any]] = sleep, **kwargs: t.Any
+        self, sleep: t.Callable[[float], t.Awaitable[t.Any]] = async_sleep, **kwargs: t.Any
     ) -> None:
         super().__init__(**kwargs)
         self.sleep = sleep

--- a/tenacity/nap.py
+++ b/tenacity/nap.py
@@ -17,6 +17,7 @@
 
 import time
 import typing
+from asyncio import sleep as asyncio_sleep
 
 if typing.TYPE_CHECKING:
     import threading
@@ -41,3 +42,12 @@ class sleep_using_event:
         # NOTE(harlowja): this may *not* actually wait for timeout
         # seconds if the event is set (ie this may eject out early).
         self.event.wait(timeout=timeout)
+
+
+async def async_sleep(seconds: float) -> None:
+    """
+    Async sleep strategy that delays execution for a given number of seconds.
+
+    To mock waiting for unit testing patch `tenacity.nap.asyncio_sleep` with a no-op.
+    """
+    await asyncio_sleep(seconds)

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -16,6 +16,7 @@
 import asyncio
 import inspect
 import unittest
+import unittest.mock
 from functools import wraps
 
 import pytest
@@ -209,6 +210,16 @@ class TestContextManager(unittest.TestCase):
             for attempts in AsyncRetrying():
                 with attempts:
                     await _async_function(thing)
+
+
+class TestAsyncSleepMocking(unittest.TestCase):
+    @asynctest
+    async def test_mock_sleep(self):
+        mock = unittest.mock.AsyncMock()
+        with unittest.mock.patch("tenacity.nap.asyncio_sleep", mock):
+            thing = NoIOErrorAfterCount(3)
+            await _retryable_coroutine(thing)
+        assert mock.await_count == 3
 
 
 # make sure mypy accepts passing an async sleep function


### PR DESCRIPTION
This PR makes it easier to mock sleeping when retrying asynchronous functions, using the same approach as was done for synchronous functions in #236.

Example usage:

```python
@retry(wait=wait_fixed(9999999))
def function_with_retry():
    if random.random() < 0.9:
        raise RuntimeError("boom")
    return True

async def test_something(self):
    with unittest.mock.patch("tenacity.nap.asyncio_sleep", AsyncMock()):
        await function_with_retry()
```

Closes #360.