### PR TITLE
fix: Restore contents of retry attribute for wrapped functions

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -124,8 +124,8 @@ retrying stuff.
         print("Stopping after 10 seconds")
         raise Exception
 
-If you're on a tight deadline, and exceeding your delay time isn't ok, 
-then you can give up on retries one attempt before you would exceed the delay. 
+If you're on a tight deadline, and exceeding your delay time isn't ok,
+then you can give up on retries one attempt before you would exceed the delay.
 
 .. testcode::
 
@@ -362,7 +362,7 @@ Statistics
 ~~~~~~~~~~
 
 You can access the statistics about the retry made over a function by using the
-`retry` attribute attached to the function and its `statistics` attribute:
+`statistics` attribute attached to the function:
 
 .. testcode::
 
@@ -375,7 +375,7 @@ You can access the statistics about the retry made over a function by using the
     except Exception:
         pass
 
-    print(raise_my_exception.retry.statistics)
+    print(raise_my_exception.statistics)
 
 .. testoutput::
    :hide:
@@ -495,7 +495,7 @@ using the `retry_with` function attached to the wrapped function:
     except Exception:
         pass
 
-    print(raise_my_exception.retry.statistics)
+    print(raise_my_exception.statistics)
 
 .. testoutput::
    :hide:
@@ -513,6 +513,32 @@ to use the `retry` decorator - you can instead use `Retrying` directly:
     def try_never_good_enough(max_attempts=3):
         retryer = Retrying(stop=stop_after_attempt(max_attempts), reraise=True)
         retryer(never_good_enough, 'I really do try')
+
+You may also want to change the behaviour of a decorated function temporarily,
+like in tests to avoid unnecessary wait times. You can modify/patch the `retry`
+attribute attached to the function. Bear in mind this is a write-only attribute,
+statistics should be read from the function `statistics` attribute.
+
+.. testcode::
+
+    @retry(stop=stop_after_attempt(3), wait=wait_fixed(3))
+    def raise_my_exception():
+        raise MyException("Fail")
+
+    from unittest import mock
+
+    with mock.patch.object(raise_my_exception.retry, "wait", wait_fixed(0)):
+        try:
+            raise_my_exception()
+        except Exception:
+            pass
+
+    print(raise_my_exception.statistics)
+
+.. testoutput::
+   :hide:
+
+   ...
 
 Retrying code block
 ~~~~~~~~~~~~~~~~~~~

--- a/releasenotes/notes/fix-retry-wrapper-attributes-f7a3a45b8e90f257.yaml
+++ b/releasenotes/notes/fix-retry-wrapper-attributes-f7a3a45b8e90f257.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Restore the value of the `retry` attribute for wrapped functions. Also,
+    clarify that those attributes are write-only and statistics should be
+    read from the function attribute directly.

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -339,7 +339,7 @@ class BaseRetrying(ABC):
             return self.copy(*args, **kwargs).wraps(f)
 
         # Preserve attributes
-        wrapped_f.retry = wrapped_f  # type: ignore[attr-defined]
+        wrapped_f.retry = self  # type: ignore[attr-defined]
         wrapped_f.retry_with = retry_with  # type: ignore[attr-defined]
         wrapped_f.statistics = {}  # type: ignore[attr-defined]
 

--- a/tenacity/asyncio/__init__.py
+++ b/tenacity/asyncio/__init__.py
@@ -189,7 +189,7 @@ class AsyncRetrying(BaseRetrying):
             return await copy(fn, *args, **kwargs)
 
         # Preserve attributes
-        async_wrapped.retry = async_wrapped  # type: ignore[attr-defined]
+        async_wrapped.retry = self  # type: ignore[attr-defined]
         async_wrapped.retry_with = wrapped.retry_with  # type: ignore[attr-defined]
         async_wrapped.statistics = {}  # type: ignore[attr-defined]
 

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -1073,7 +1073,7 @@ class TestDecoratorWrapper(unittest.TestCase):
                 _retryable_test_with_unless_exception_type_name(NameErrorUntilCount(5))
             )
         except NameError as e:
-            s = _retryable_test_with_unless_exception_type_name.retry.statistics
+            s = _retryable_test_with_unless_exception_type_name.statistics
             self.assertTrue(s["attempt_number"] == 6)
             print(e)
         else:
@@ -1088,7 +1088,7 @@ class TestDecoratorWrapper(unittest.TestCase):
                 )
             )
         except NameError as e:
-            s = _retryable_test_with_unless_exception_type_no_input.retry.statistics
+            s = _retryable_test_with_unless_exception_type_no_input.statistics
             self.assertTrue(s["attempt_number"] == 6)
             print(e)
         else:
@@ -1111,7 +1111,7 @@ class TestDecoratorWrapper(unittest.TestCase):
                 _retryable_test_if_exception_message_message(NoCustomErrorAfterCount(3))
             )
         except CustomError:
-            print(_retryable_test_if_exception_message_message.retry.statistics)
+            print(_retryable_test_if_exception_message_message.statistics)
             self.fail("CustomError should've been retried from errormessage")
 
     def test_retry_if_not_exception_message(self):
@@ -1122,7 +1122,7 @@ class TestDecoratorWrapper(unittest.TestCase):
                 )
             )
         except CustomError:
-            s = _retryable_test_if_not_exception_message_message.retry.statistics
+            s = _retryable_test_if_not_exception_message_message.statistics
             self.assertTrue(s["attempt_number"] == 1)
 
     def test_retry_if_not_exception_message_delay(self):
@@ -1131,7 +1131,7 @@ class TestDecoratorWrapper(unittest.TestCase):
                 _retryable_test_not_exception_message_delay(NameErrorUntilCount(3))
             )
         except NameError:
-            s = _retryable_test_not_exception_message_delay.retry.statistics
+            s = _retryable_test_not_exception_message_delay.statistics
             print(s["attempt_number"])
             self.assertTrue(s["attempt_number"] == 4)
 
@@ -1151,7 +1151,7 @@ class TestDecoratorWrapper(unittest.TestCase):
                 )
             )
         except CustomError:
-            s = _retryable_test_if_not_exception_message_message.retry.statistics
+            s = _retryable_test_if_not_exception_message_message.statistics
             self.assertTrue(s["attempt_number"] == 1)
 
     def test_retry_if_exception_cause_type(self):
@@ -1479,21 +1479,21 @@ class TestStatistics(unittest.TestCase):
         def _foobar():
             return 42
 
-        self.assertEqual({}, _foobar.retry.statistics)
+        self.assertEqual({}, _foobar.statistics)
         _foobar()
-        self.assertEqual(1, _foobar.retry.statistics["attempt_number"])
+        self.assertEqual(1, _foobar.statistics["attempt_number"])
 
     def test_stats_failing(self):
         @retry(stop=tenacity.stop_after_attempt(2))
         def _foobar():
             raise ValueError(42)
 
-        self.assertEqual({}, _foobar.retry.statistics)
+        self.assertEqual({}, _foobar.statistics)
         try:
             _foobar()
         except Exception:  # noqa: B902
             pass
-        self.assertEqual(2, _foobar.retry.statistics["attempt_number"])
+        self.assertEqual(2, _foobar.statistics["attempt_number"])
 
 
 class TestRetryErrorCallback(unittest.TestCase):


### PR DESCRIPTION
Fixes #482 

After https://github.com/jd/tenacity/pull/479 we changed the contents of the `retry` attribute for retry wrapped functions. However, it is useful that this attribute contains the reference to the retry object as it allows to modify its behaviour on-the-fly. Simply restoring the previous behaviour not possible, as they assume the contents of the `retry` attribute can be read, but recursive calls may end up overwriting the same context and make this invalid (see the discussion in #482). These changes restore the `retry` attribute, and update both tests and docs to make clear this is a write-only attribute and statistics should be read from the separate `statistics` attribute in the wrapped function.