### PR TITLE
chore: Allow combining non base-derived objects for retries

### DIFF
--- a/releasenotes/notes/allow-retry-callables-ba921a2b57229540.yaml
+++ b/releasenotes/notes/allow-retry-callables-ba921a2b57229540.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Allow for callables to be combined as retry values. This will only
+    work when used combined with their corresponding implementation
+    retry objects, e.g. only async functions will work when used together
+    with async retry strategies.

--- a/tenacity/asyncio/retry.py
+++ b/tenacity/asyncio/retry.py
@@ -104,7 +104,7 @@ class retry_any(async_retry_base):
     async def __call__(self, retry_state: "RetryCallState") -> bool:  # type: ignore[override]
         result = False
         for r in self.retries:
-            result = result or await _utils.wrap_to_async_func(r)(retry_state)
+            result = result or (await _utils.wrap_to_async_func(r)(retry_state) is True)
             if result:
                 break
         return result
@@ -119,7 +119,9 @@ class retry_all(async_retry_base):
     async def __call__(self, retry_state: "RetryCallState") -> bool:  # type: ignore[override]
         result = True
         for r in self.retries:
-            result = result and await _utils.wrap_to_async_func(r)(retry_state)
+            result = result and (
+                await _utils.wrap_to_async_func(r)(retry_state) is True
+            )
             if not result:
                 break
         return result

--- a/tenacity/retry.py
+++ b/tenacity/retry.py
@@ -30,15 +30,29 @@ class retry_base(abc.ABC):
         pass
 
     def __and__(self, other: "retry_base") -> "retry_all":
-        return other.__rand__(self)
+        if isinstance(other, retry_base):
+            # Delegate to the other object to allow for specific
+            # implementations, such as asyncio
+            return other.__rand__(self)
+        return retry_all(other, self)
 
     def __rand__(self, other: "retry_base") -> "retry_all":
+        # This is automatically invoked for inheriting classes,
+        # so it helps to keep the abstraction and delegate specific
+        # implementations, such as asyncio
         return retry_all(other, self)
 
     def __or__(self, other: "retry_base") -> "retry_any":
-        return other.__ror__(self)
+        if isinstance(other, retry_base):
+            # Delegate to the other object to allow for specific
+            # implementations, such as asyncio
+            return other.__ror__(self)
+        return retry_any(other, self)
 
     def __ror__(self, other: "retry_base") -> "retry_any":
+        # This is automatically invoked for inheriting classes,
+        # so it helps to keep the abstraction and delegate specific
+        # implementations, such as asyncio
         return retry_any(other, self)
 
 

--- a/tenacity/retry.py
+++ b/tenacity/retry.py
@@ -283,7 +283,7 @@ class retry_any(retry_base):
         self.retries = retries
 
     def __call__(self, retry_state: "RetryCallState") -> bool:
-        return any(r(retry_state) for r in self.retries)
+        return any(r(retry_state) is True for r in self.retries)
 
 
 class retry_all(retry_base):
@@ -293,4 +293,4 @@ class retry_all(retry_base):
         self.retries = retries
 
     def __call__(self, retry_state: "RetryCallState") -> bool:
-        return all(r(retry_state) for r in self.retries)
+        return all(r(retry_state) is True for r in self.retries)

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -633,6 +633,58 @@ class TestRetryConditions(unittest.TestCase):
         self.assertFalse(r(tenacity.Future.construct(1, 3, False)))
         self.assertFalse(r(tenacity.Future.construct(1, 1, True)))
 
+    async def test_retry_and_func(self):
+        def test():
+            attempts = 0
+            called = False
+
+            def lt_3(x: float) -> bool:
+                return x < 3
+
+            def should_retry(retry_state: RetryCallState) -> bool:
+                nonlocal called
+                called = True
+                return True
+
+            retry_strategy = tenacity.retry_if_result(lt_3) & should_retry  # type: ignore[operator]
+            for attempt in Retrying(retry=retry_strategy):
+                with attempt:
+                    attempts += 1
+                attempt.retry_state.set_result(attempts)
+
+            self.assertTrue(called)
+            return attempts
+
+        result = test()
+
+        self.assertEqual(3, result)
+
+    async def test_retry_rand_func(self):
+        def test():
+            attempts = 0
+            called = False
+
+            def lt_3(x: float) -> bool:
+                return x < 3
+
+            def should_retry(retry_state: RetryCallState) -> bool:
+                nonlocal called
+                called = True
+                return True
+
+            retry_strategy = should_retry & tenacity.retry_if_result(lt_3)  # type: ignore[operator]
+            for attempt in Retrying(retry=retry_strategy):
+                with attempt:
+                    attempts += 1
+                attempt.retry_state.set_result(attempts)
+
+            self.assertTrue(called)
+            return attempts
+
+        result = test()
+
+        self.assertEqual(3, result)
+
     def test_retry_or(self):
         retry = tenacity.retry_if_result(
             lambda x: x == "foo"
@@ -646,6 +698,64 @@ class TestRetryConditions(unittest.TestCase):
         self.assertFalse(r(tenacity.Future.construct(1, "foobar", False)))
         self.assertFalse(r(tenacity.Future.construct(1, 2.2, False)))
         self.assertFalse(r(tenacity.Future.construct(1, 42, True)))
+
+    def test_retry_or_func(self):
+        def test():
+            attempts = 0
+            called = False
+
+            def lt_3(x: float) -> bool:
+                return x < 3
+
+            def should_retry(retry_state: RetryCallState) -> bool:
+                nonlocal called
+                called = True
+                return False
+
+            retry_strategy = tenacity.retry_if_result(lt_3) | should_retry  # type: ignore[operator]
+            for attempt in Retrying(retry=retry_strategy):
+                with attempt:
+                    attempts += 1
+
+                assert attempt.retry_state.outcome  # help mypy
+                if not attempt.retry_state.outcome.failed:
+                    attempt.retry_state.set_result(attempts)
+
+            self.assertTrue(called)
+            return attempts
+
+        result = test()
+
+        self.assertEqual(3, result)
+
+    def test_retry_ror_func(self):
+        def test():
+            attempts = 0
+            called = False
+
+            def lt_3(x: float) -> bool:
+                return x < 3
+
+            def should_retry(retry_state: RetryCallState) -> bool:
+                nonlocal called
+                called = True
+                return False
+
+            retry_strategy = should_retry | tenacity.retry_if_result(lt_3)  # type: ignore[operator]
+            for attempt in Retrying(retry=retry_strategy):
+                with attempt:
+                    attempts += 1
+
+                assert attempt.retry_state.outcome  # help mypy
+                if not attempt.retry_state.outcome.failed:
+                    attempt.retry_state.set_result(attempts)
+
+            self.assertTrue(called)
+            return attempts
+
+        result = test()
+
+        self.assertEqual(3, result)
 
     def _raise_try_again(self):
         self._attempts += 1


### PR DESCRIPTION
Fixes #481 

Versions prior to introducing https://github.com/jd/tenacity/pull/451 inadvertently allowed to use plain callables as retry strategies, as opposed to `retry_base` deriving classes, as they conform to the `__call__` typing. It is not a big must, but slightly changing the `__and__`/`__or__` checks would allow for that again.

NOTE: combining non-async strategies with async functions will not work, other combinations should, as the tests show.