### PR TITLE
docs: unify the name `before sleep strategy` in docstring and comments

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -76,7 +76,7 @@ from .before import before_nothing  # noqa
 from .after import after_log  # noqa
 from .after import after_nothing  # noqa
 
-# Import all built-in after strategies for easier usage.
+# Import all built-in before sleep strategies for easier usage.
 from .before_sleep import before_sleep_log  # noqa
 from .before_sleep import before_sleep_nothing  # noqa
 

--- a/tenacity/before_sleep.py
+++ b/tenacity/before_sleep.py
@@ -25,7 +25,7 @@ if typing.TYPE_CHECKING:
 
 
 def before_sleep_nothing(retry_state: "RetryCallState") -> None:
-    """Before call strategy that does nothing."""
+    """Before sleep strategy that does nothing."""
 
 
 def before_sleep_log(
@@ -33,7 +33,7 @@ def before_sleep_log(
     log_level: int,
     exc_info: bool = False,
 ) -> typing.Callable[["RetryCallState"], None]:
-    """Before call strategy that logs to some logger the attempt."""
+    """Before sleep strategy that logs to some logger the attempt."""
 
     def log_it(retry_state: "RetryCallState") -> None:
         local_exc_info: BaseException | bool | None


### PR DESCRIPTION
Simply fix some wrong names in comments.
Feel free to push changes directly if needed, as I may be slow to respond.