### PR TITLE
handle statistics update even if statistics dict not initialized

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -425,8 +425,10 @@ class BaseRetrying(ABC):
             sleep = rs.upcoming_sleep
             rs.next_action = RetryAction(sleep)
             rs.idle_for += sleep
-            self.statistics["idle_for"] += sleep
-            self.statistics["attempt_number"] += 1
+            self.statistics["idle_for"] = self.statistics.get("idle_for", 0) + sleep
+            self.statistics["attempt_number"] = (
+                self.statistics.get("attempt_number", 0) + 1
+            )
 
         self._add_action_func(next_action)
 

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -427,7 +427,7 @@ class BaseRetrying(ABC):
             rs.idle_for += sleep
             self.statistics["idle_for"] = self.statistics.get("idle_for", 0) + sleep
             self.statistics["attempt_number"] = (
-                self.statistics.get("attempt_number", 0) + 1
+                self.statistics.get("attempt_number", 1) + 1
             )
 
         self._add_action_func(next_action)


### PR DESCRIPTION
Issue: https://github.com/jd/tenacity/issues/507

Handle `KeyError` that occurs in edge cases by changing instances of self.statistics[key] += ... to self.statistics[key] = self.statistics.get(key, ...) + ...

This will eliminate keyerrors.

In the cases where statistics isn't initialized with begin(), this will still not ensure that it's correct, but will ensure that we retry instead of crashing.

Alternately, 

```
            self.statistics["idle_for"] = rs.idle_for
            self.statistics["attempt_number"] = rs.attempt_number
```

might be more accurate.