### PR TITLE
fix: return "Self" from "BaseRetrying.copy"

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -88,6 +88,8 @@ except ImportError:
 if t.TYPE_CHECKING:
     import types
 
+    from typing_extensions import Self
+
     from . import asyncio as tasyncio
     from .retry import RetryBaseT
     from .stop import StopBaseT
@@ -255,7 +257,7 @@ class BaseRetrying(ABC):
         retry_error_callback: t.Union[
             t.Optional[t.Callable[["RetryCallState"], t.Any]], object
         ] = _unset,
-    ) -> "BaseRetrying":
+    ) -> "Self":
         """Copy this object with some parameters changed if needed."""
         return self.__class__(
             sleep=_first_set(sleep, self.sleep),


### PR DESCRIPTION
Currently `BaseRetrying.copy` returns `BaseRetrying`, making reusing a "template"/base retrying object harder.
Example usecase:
```py
from tenacity import AsyncRetrying


class SomeClient:
    def __init__(self, retry: AsyncRetrying) -> None:
        self._retry = retry

    async def method(self) -> None:
        async for attempt in self._retry.copy():
            with attempt:
                pass  # Do something
```
```sh
$ mypy main.py 
main.py:9: error: "BaseRetrying" has no attribute "__aiter__" (not async iterable)  [attr-defined]
Found 1 error in 1 file (checked 1 source file)
```