### PR TITLE
docs: fix syntax error in wait_chain docstring example

### DIFF
--- a/tenacity/wait.py
+++ b/tenacity/wait.py
@@ -98,10 +98,10 @@ class wait_chain(wait_base):
 
         @retry(wait=wait_chain(*[wait_fixed(1) for i in range(3)] +
                                [wait_fixed(2) for j in range(5)] +
-                               [wait_fixed(5) for k in range(4)))
+                               [wait_fixed(5) for k in range(4)]))
         def wait_chained():
-            print("Wait 1s for 3 attempts, 2s for 5 attempts and 5s
-                   thereafter.")
+            print("Wait 1s for 3 attempts, 2s for 5 attempts and 5s "
+                  "thereafter.")
     """
 
     def __init__(self, *strategies: wait_base) -> None:


### PR DESCRIPTION
Fix the missing closing bracket in the wait_chain docstring example code. The example had an unbalanced bracket which would cause a SyntaxError if copied. Also properly format the multi-line string in the print statement. Closes #250