### PR TITLE
Support async sleep for sync fn-to-retry

### DIFF
--- a/releasenotes/notes/async-sleep-retrying-32de5866f5d041.yaml
+++ b/releasenotes/notes/async-sleep-retrying-32de5866f5d041.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Passing an async ``sleep`` callable (e.g. ``trio.sleep``) to ``@retry``
+    now correctly uses ``AsyncRetrying``, even when the decorated function is
+    synchronous. Previously, the async sleep would silently not be awaited,
+    resulting in no delay between retries.


### PR DESCRIPTION
This enables us to avoid blocking the async runloop, without needing to trivially wrap the function-to-retry.

Unfortunately the relevant introspection functions are new in Python 3.10; since [Python 3.9 is EOL](https://devguide.python.org/versions/) I've also dropped it from metadata and CI configs.