### PR TITLE
chore: enable ruff I, UP, B rules and auto-fix codebase

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,14 @@ indent-width = 4
 target-version = "py310"
 exclude = ["tenacity/_version.py"]
 
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B"]
+ignore = [
+    "B008",  # function calls in default arguments (intentional API design)
+    "B905",  # zip() without strict= (not needed in existing code)
+    "E501",  # line too long (formatter handles what it can)
+]
+
 [tool.mypy]
 strict = true
 files = ["tenacity", "tests"]

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -28,59 +28,73 @@ from concurrent import futures
 
 from . import _utils
 
-# Import all built-in retry strategies for easier usage.
-from .retry import retry_base  # noqa
-from .retry import retry_all  # noqa
-from .retry import retry_always  # noqa
-from .retry import retry_any  # noqa
-from .retry import retry_if_exception  # noqa
-from .retry import retry_if_exception_type  # noqa
-from .retry import retry_if_exception_cause_type  # noqa
-from .retry import retry_if_not_exception_type  # noqa
-from .retry import retry_if_not_result  # noqa
-from .retry import retry_if_result  # noqa
-from .retry import retry_never  # noqa
-from .retry import retry_unless_exception_type  # noqa
-from .retry import retry_if_exception_message  # noqa
-from .retry import retry_if_not_exception_message  # noqa
-
-# Import all nap strategies for easier usage.
-from .nap import sleep  # noqa
-from .nap import sleep_using_event  # noqa
-
-# Import all built-in stop strategies for easier usage.
-from .stop import stop_after_attempt  # noqa
-from .stop import stop_after_delay  # noqa
-from .stop import stop_before_delay  # noqa
-from .stop import stop_all  # noqa
-from .stop import stop_any  # noqa
-from .stop import stop_never  # noqa
-from .stop import stop_when_event_set  # noqa
-
-# Import all built-in wait strategies for easier usage.
-from .wait import wait_chain  # noqa
-from .wait import wait_combine  # noqa
-from .wait import wait_exception  # noqa
-from .wait import wait_exponential  # noqa
-from .wait import wait_fixed  # noqa
-from .wait import wait_incrementing  # noqa
-from .wait import wait_none  # noqa
-from .wait import wait_random  # noqa
-from .wait import wait_random_exponential  # noqa
-from .wait import wait_random_exponential as wait_full_jitter  # noqa
-from .wait import wait_exponential_jitter  # noqa
+# Import all built-in after strategies for easier usage.
+from .after import (
+    after_log,  # noqa
+    after_nothing,  # noqa
+)
 
 # Import all built-in before strategies for easier usage.
-from .before import before_log  # noqa
-from .before import before_nothing  # noqa
-
-# Import all built-in after strategies for easier usage.
-from .after import after_log  # noqa
-from .after import after_nothing  # noqa
+from .before import (
+    before_log,  # noqa
+    before_nothing,  # noqa
+)
 
 # Import all built-in before sleep strategies for easier usage.
-from .before_sleep import before_sleep_log  # noqa
-from .before_sleep import before_sleep_nothing  # noqa
+from .before_sleep import (
+    before_sleep_log,  # noqa
+    before_sleep_nothing,  # noqa
+)
+
+# Import all nap strategies for easier usage.
+from .nap import (
+    sleep,  # noqa
+    sleep_using_event,  # noqa
+)
+
+# Import all built-in retry strategies for easier usage.
+from .retry import (
+    retry_all,  # noqa
+    retry_always,  # noqa
+    retry_any,  # noqa
+    retry_base,  # noqa
+    retry_if_exception,  # noqa
+    retry_if_exception_cause_type,  # noqa
+    retry_if_exception_message,  # noqa
+    retry_if_exception_type,  # noqa
+    retry_if_not_exception_message,  # noqa
+    retry_if_not_exception_type,  # noqa
+    retry_if_not_result,  # noqa
+    retry_if_result,  # noqa
+    retry_never,  # noqa
+    retry_unless_exception_type,  # noqa
+)
+
+# Import all built-in stop strategies for easier usage.
+from .stop import (
+    stop_after_attempt,  # noqa
+    stop_after_delay,  # noqa
+    stop_all,  # noqa
+    stop_any,  # noqa
+    stop_before_delay,  # noqa
+    stop_never,  # noqa
+    stop_when_event_set,  # noqa
+)
+
+# Import all built-in wait strategies for easier usage.
+from .wait import (
+    wait_chain,  # noqa
+    wait_combine,  # noqa
+    wait_exception,  # noqa
+    wait_exponential,  # noqa
+    wait_exponential_jitter,  # noqa
+    wait_fixed,  # noqa
+    wait_incrementing,  # noqa
+    wait_none,  # noqa
+    wait_random,  # noqa
+    wait_random_exponential,  # noqa
+)
+from .wait import wait_random_exponential as wait_full_jitter  # noqa
 
 try:
     import tornado
@@ -104,7 +118,7 @@ R = t.TypeVar("R")
 
 @dataclasses.dataclass(slots=True)
 class IterState:
-    actions: t.List[t.Callable[["RetryCallState"], t.Any]] = dataclasses.field(
+    actions: list[t.Callable[["RetryCallState"], t.Any]] = dataclasses.field(
         default_factory=list
     )
     retry_run_result: bool = False
@@ -145,7 +159,7 @@ class BaseAction:
     """
 
     REPR_FIELDS: t.Sequence[str] = ()
-    NAME: t.Optional[str] = None
+    NAME: str | None = None
 
     def __repr__(self) -> str:
         state_str = ", ".join(
@@ -168,7 +182,7 @@ class RetryAction(BaseAction):
 _unset = object()
 
 
-def _first_set(first: t.Union[t.Any, object], second: t.Any) -> t.Any:
+def _first_set(first: t.Any | object, second: t.Any) -> t.Any:
     return second if first is _unset else first
 
 
@@ -199,10 +213,10 @@ class AttemptManager:
 
     def __exit__(
         self,
-        exc_type: t.Optional[t.Type[BaseException]],
-        exc_value: t.Optional[BaseException],
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
         traceback: t.Optional["types.TracebackType"],
-    ) -> t.Optional[bool]:
+    ) -> bool | None:
         if exc_type is not None and exc_value is not None:
             self.retry_state.set_exception((exc_type, exc_value, traceback))
             return True  # Swallow exception.
@@ -215,16 +229,16 @@ class AttemptManager:
 class BaseRetrying(ABC):
     def __init__(
         self,
-        sleep: t.Callable[[t.Union[int, float]], None] = sleep,
+        sleep: t.Callable[[int | float], None] = sleep,
         stop: "StopBaseT" = stop_never,
         wait: "WaitBaseT" = wait_none(),
         retry: "RetryBaseT" = retry_if_exception_type(),
         before: t.Callable[["RetryCallState"], None] = before_nothing,
         after: t.Callable[["RetryCallState"], None] = after_nothing,
-        before_sleep: t.Optional[t.Callable[["RetryCallState"], None]] = None,
+        before_sleep: t.Callable[["RetryCallState"], None] | None = None,
         reraise: bool = False,
-        retry_error_cls: t.Type[RetryError] = RetryError,
-        retry_error_callback: t.Optional[t.Callable[["RetryCallState"], t.Any]] = None,
+        retry_error_cls: type[RetryError] = RetryError,
+        retry_error_callback: t.Callable[["RetryCallState"], t.Any] | None = None,
     ):
         self.sleep = sleep
         self.stop = stop
@@ -240,20 +254,18 @@ class BaseRetrying(ABC):
 
     def copy(
         self,
-        sleep: t.Union[t.Callable[[t.Union[int, float]], None], object] = _unset,
+        sleep: t.Callable[[int | float], None] | object = _unset,
         stop: t.Union["StopBaseT", object] = _unset,
         wait: t.Union["WaitBaseT", object] = _unset,
-        retry: t.Union[retry_base, object] = _unset,
-        before: t.Union[t.Callable[["RetryCallState"], None], object] = _unset,
-        after: t.Union[t.Callable[["RetryCallState"], None], object] = _unset,
-        before_sleep: t.Union[
-            t.Optional[t.Callable[["RetryCallState"], None]], object
-        ] = _unset,
-        reraise: t.Union[bool, object] = _unset,
-        retry_error_cls: t.Union[t.Type[RetryError], object] = _unset,
-        retry_error_callback: t.Union[
-            t.Optional[t.Callable[["RetryCallState"], t.Any]], object
-        ] = _unset,
+        retry: retry_base | object = _unset,
+        before: t.Callable[["RetryCallState"], None] | object = _unset,
+        after: t.Callable[["RetryCallState"], None] | object = _unset,
+        before_sleep: t.Callable[["RetryCallState"], None] | None | object = _unset,
+        reraise: bool | object = _unset,
+        retry_error_cls: type[RetryError] | object = _unset,
+        retry_error_callback: t.Callable[["RetryCallState"], t.Any]
+        | None
+        | object = _unset,
     ) -> "Self":
         """Copy this object with some parameters changed if needed."""
         return self.__class__(
@@ -283,7 +295,7 @@ class BaseRetrying(ABC):
         )
 
     @property
-    def statistics(self) -> t.Dict[str, t.Any]:
+    def statistics(self) -> dict[str, t.Any]:
         """Return a dictionary of runtime statistics.
 
         This dictionary will be empty when the controller has never been
@@ -305,7 +317,7 @@ class BaseRetrying(ABC):
                   statistics from each thread).
         """
         if not hasattr(self._local, "statistics"):
-            self._local.statistics = t.cast(t.Dict[str, t.Any], {})
+            self._local.statistics = t.cast(dict[str, t.Any], {})
         return self._local.statistics  # type: ignore[no-any-return]
 
     @property
@@ -471,7 +483,7 @@ class Retrying(BaseRetrying):
             if isinstance(do, DoAttempt):
                 try:
                     result = fn(*args, **kwargs)
-                except BaseException:  # noqa: B902
+                except BaseException:
                     retry_state.set_exception(sys.exc_info())  # type: ignore[arg-type]
                 else:
                     retry_state.set_result(result)
@@ -513,7 +525,7 @@ class RetryCallState:
     def __init__(
         self,
         retry_object: BaseRetrying,
-        fn: t.Optional[WrappedFn],
+        fn: WrappedFn | None,
         args: t.Any,
         kwargs: t.Any,
     ) -> None:
@@ -531,18 +543,18 @@ class RetryCallState:
         #: The number of the current attempt
         self.attempt_number: int = 1
         #: Last outcome (result or exception) produced by the function
-        self.outcome: t.Optional[Future] = None
+        self.outcome: Future | None = None
         #: Timestamp of the last outcome
-        self.outcome_timestamp: t.Optional[float] = None
+        self.outcome_timestamp: float | None = None
         #: Time spent sleeping in retries
         self.idle_for: float = 0.0
         #: Next action as decided by the retry manager
-        self.next_action: t.Optional[RetryAction] = None
+        self.next_action: RetryAction | None = None
         #: Next sleep time as decided by the retry manager.
         self.upcoming_sleep: float = 0.0
 
     @property
-    def seconds_since_start(self) -> t.Optional[float]:
+    def seconds_since_start(self) -> float | None:
         if self.outcome_timestamp is None:
             return None
         return self.outcome_timestamp - self.start_time
@@ -561,8 +573,8 @@ class RetryCallState:
 
     def set_exception(
         self,
-        exc_info: t.Tuple[
-            t.Type[BaseException], BaseException, "types.TracebackType| None"
+        exc_info: tuple[
+            type[BaseException], BaseException, "types.TracebackType| None"
         ],
     ) -> None:
         ts = time.monotonic()
@@ -608,43 +620,34 @@ def retry(func: WrappedFn) -> WrappedFn: ...
 @t.overload
 def retry(
     *,
-    sleep: t.Callable[[t.Union[int, float]], t.Awaitable[None]],
+    sleep: t.Callable[[int | float], t.Awaitable[None]],
     stop: "StopBaseT" = ...,
     wait: "WaitBaseT" = ...,
-    retry: "t.Union[RetryBaseT, tasyncio.retry.RetryBaseT]" = ...,
-    before: t.Callable[["RetryCallState"], t.Union[None, t.Awaitable[None]]] = ...,
-    after: t.Callable[["RetryCallState"], t.Union[None, t.Awaitable[None]]] = ...,
-    before_sleep: t.Optional[
-        t.Callable[["RetryCallState"], t.Union[None, t.Awaitable[None]]]
-    ] = ...,
+    retry: "RetryBaseT | tasyncio.retry.RetryBaseT" = ...,
+    before: t.Callable[["RetryCallState"], None | t.Awaitable[None]] = ...,
+    after: t.Callable[["RetryCallState"], None | t.Awaitable[None]] = ...,
+    before_sleep: t.Callable[["RetryCallState"], None | t.Awaitable[None]] | None = ...,
     reraise: bool = ...,
-    retry_error_cls: t.Type["RetryError"] = ...,
-    retry_error_callback: t.Optional[
-        t.Callable[["RetryCallState"], t.Union[t.Any, t.Awaitable[t.Any]]]
-    ] = ...,
+    retry_error_cls: type["RetryError"] = ...,
+    retry_error_callback: t.Callable[["RetryCallState"], t.Any | t.Awaitable[t.Any]]
+    | None = ...,
 ) -> _AsyncRetryDecorator: ...
 
 
 @t.overload
 def retry(
-    sleep: t.Callable[[t.Union[int, float]], None] = sleep,
+    sleep: t.Callable[[int | float], None] = sleep,
     stop: "StopBaseT" = stop_never,
     wait: "WaitBaseT" = wait_none(),
-    retry: "t.Union[RetryBaseT, tasyncio.retry.RetryBaseT]" = retry_if_exception_type(),
-    before: t.Callable[
-        ["RetryCallState"], t.Union[None, t.Awaitable[None]]
-    ] = before_nothing,
-    after: t.Callable[
-        ["RetryCallState"], t.Union[None, t.Awaitable[None]]
-    ] = after_nothing,
-    before_sleep: t.Optional[
-        t.Callable[["RetryCallState"], t.Union[None, t.Awaitable[None]]]
-    ] = None,
+    retry: "RetryBaseT | tasyncio.retry.RetryBaseT" = retry_if_exception_type(),
+    before: t.Callable[["RetryCallState"], None | t.Awaitable[None]] = before_nothing,
+    after: t.Callable[["RetryCallState"], None | t.Awaitable[None]] = after_nothing,
+    before_sleep: t.Callable[["RetryCallState"], None | t.Awaitable[None]]
+    | None = None,
     reraise: bool = False,
-    retry_error_cls: t.Type["RetryError"] = RetryError,
-    retry_error_callback: t.Optional[
-        t.Callable[["RetryCallState"], t.Union[t.Any, t.Awaitable[t.Any]]]
-    ] = None,
+    retry_error_cls: type["RetryError"] = RetryError,
+    retry_error_callback: t.Callable[["RetryCallState"], t.Any | t.Awaitable[t.Any]]
+    | None = None,
 ) -> t.Callable[[WrappedFn], WrappedFn]: ...
 
 
@@ -663,9 +666,10 @@ def retry(*dargs: t.Any, **dkw: t.Any) -> t.Any:
             if isinstance(f, retry_base):
                 warnings.warn(
                     f"Got retry_base instance ({f.__class__.__name__}) as callable argument, "
-                    f"this will probably hang indefinitely (did you mean retry={f.__class__.__name__}(...)?)"
+                    f"this will probably hang indefinitely (did you mean retry={f.__class__.__name__}(...)?)",
+                    stacklevel=2,
                 )
-            r: "BaseRetrying"
+            r: BaseRetrying
             sleep = dkw.get("sleep")
             if _utils.is_coroutine_callable(f) or (
                 sleep is not None and _utils.is_coroutine_callable(sleep)
@@ -685,7 +689,7 @@ def retry(*dargs: t.Any, **dkw: t.Any) -> t.Any:
         return wrap
 
 
-from tenacity.asyncio import AsyncRetrying  # noqa:E402,I100
+from tenacity.asyncio import AsyncRetrying  # noqa: E402
 
 if tornado:
     from tenacity.tornadoweb import TornadoRetrying

--- a/tenacity/_utils.py
+++ b/tenacity/_utils.py
@@ -19,7 +19,6 @@ import sys
 import typing
 from datetime import timedelta
 
-
 # sys.maxsize:
 # An integer giving the maximum value a variable of type Py_ssize_t can take.
 MAX_WAIT = sys.maxsize / 2
@@ -86,7 +85,7 @@ def get_callback_name(cb: typing.Callable[..., typing.Any]) -> str:
         return ".".join(segments)
 
 
-time_unit_type = typing.Union[int, float, timedelta]
+time_unit_type = int | float | timedelta
 
 
 def to_seconds(time_unit: time_unit_type) -> float:
@@ -101,7 +100,7 @@ def is_coroutine_callable(call: typing.Callable[..., typing.Any]) -> bool:
     if inspect.iscoroutinefunction(call):
         return True
     partial_call = isinstance(call, functools.partial) and call.func
-    dunder_call = partial_call or getattr(call, "__call__", None)
+    dunder_call = partial_call or getattr(call, "__call__", None)  # noqa: B004
     return inspect.iscoroutinefunction(dunder_call)
 
 

--- a/tenacity/asyncio/retry.py
+++ b/tenacity/asyncio/retry.py
@@ -16,8 +16,7 @@
 import abc
 import typing
 
-from tenacity import _utils
-from tenacity import retry_base
+from tenacity import _utils, retry_base
 
 if typing.TYPE_CHECKING:
     from tenacity import RetryCallState
@@ -31,29 +30,29 @@ class async_retry_base(retry_base):
         pass
 
     def __and__(  # type: ignore[override]
-        self, other: "typing.Union[retry_base, async_retry_base]"
+        self, other: "retry_base | async_retry_base"
     ) -> "retry_all":
         return retry_all(self, other)
 
     def __rand__(  # type: ignore[misc,override]
-        self, other: "typing.Union[retry_base, async_retry_base]"
+        self, other: "retry_base | async_retry_base"
     ) -> "retry_all":
         return retry_all(other, self)
 
     def __or__(  # type: ignore[override]
-        self, other: "typing.Union[retry_base, async_retry_base]"
+        self, other: "retry_base | async_retry_base"
     ) -> "retry_any":
         return retry_any(self, other)
 
     def __ror__(  # type: ignore[misc,override]
-        self, other: "typing.Union[retry_base, async_retry_base]"
+        self, other: "retry_base | async_retry_base"
     ) -> "retry_any":
         return retry_any(other, self)
 
 
-RetryBaseT = typing.Union[
-    async_retry_base, typing.Callable[["RetryCallState"], typing.Awaitable[bool]]
-]
+RetryBaseT = (
+    async_retry_base | typing.Callable[["RetryCallState"], typing.Awaitable[bool]]
+)
 
 
 class retry_if_exception(async_retry_base):
@@ -98,7 +97,7 @@ class retry_if_result(async_retry_base):
 class retry_any(async_retry_base):
     """Retries if any of the retries condition is valid."""
 
-    def __init__(self, *retries: typing.Union[retry_base, async_retry_base]) -> None:
+    def __init__(self, *retries: retry_base | async_retry_base) -> None:
         self.retries = retries
 
     async def __call__(self, retry_state: "RetryCallState") -> bool:  # type: ignore[override]
@@ -113,7 +112,7 @@ class retry_any(async_retry_base):
 class retry_all(async_retry_base):
     """Retries if all the retries condition are valid."""
 
-    def __init__(self, *retries: typing.Union[retry_base, async_retry_base]) -> None:
+    def __init__(self, *retries: retry_base | async_retry_base) -> None:
         self.retries = retries
 
     async def __call__(self, retry_state: "RetryCallState") -> bool:  # type: ignore[override]

--- a/tenacity/nap.py
+++ b/tenacity/nap.py
@@ -37,7 +37,7 @@ class sleep_using_event:
     def __init__(self, event: "threading.Event") -> None:
         self.event = event
 
-    def __call__(self, timeout: typing.Optional[float]) -> None:
+    def __call__(self, timeout: float | None) -> None:
         # NOTE(harlowja): this may *not* actually wait for timeout
         # seconds if the event is set (ie this may eject out early).
         self.event.wait(timeout=timeout)

--- a/tenacity/retry.py
+++ b/tenacity/retry.py
@@ -42,7 +42,7 @@ class retry_base(abc.ABC):
         return retry_any(other, self)
 
 
-RetryBaseT = typing.Union[retry_base, typing.Callable[["RetryCallState"], bool]]
+RetryBaseT = retry_base | typing.Callable[["RetryCallState"], bool]
 
 
 class _retry_never(retry_base):
@@ -89,10 +89,8 @@ class retry_if_exception_type(retry_if_exception):
 
     def __init__(
         self,
-        exception_types: typing.Union[
-            typing.Type[BaseException],
-            typing.Tuple[typing.Type[BaseException], ...],
-        ] = Exception,
+        exception_types: type[BaseException]
+        | tuple[type[BaseException], ...] = Exception,
     ) -> None:
         self.exception_types = exception_types
         super().__init__(lambda e: isinstance(e, exception_types))
@@ -103,10 +101,8 @@ class retry_if_not_exception_type(retry_if_exception):
 
     def __init__(
         self,
-        exception_types: typing.Union[
-            typing.Type[BaseException],
-            typing.Tuple[typing.Type[BaseException], ...],
-        ] = Exception,
+        exception_types: type[BaseException]
+        | tuple[type[BaseException], ...] = Exception,
     ) -> None:
         self.exception_types = exception_types
         super().__init__(lambda e: not isinstance(e, exception_types))
@@ -117,10 +113,8 @@ class retry_unless_exception_type(retry_if_exception):
 
     def __init__(
         self,
-        exception_types: typing.Union[
-            typing.Type[BaseException],
-            typing.Tuple[typing.Type[BaseException], ...],
-        ] = Exception,
+        exception_types: type[BaseException]
+        | tuple[type[BaseException], ...] = Exception,
     ) -> None:
         self.exception_types = exception_types
         super().__init__(lambda e: not isinstance(e, exception_types))
@@ -148,10 +142,8 @@ class retry_if_exception_cause_type(retry_base):
 
     def __init__(
         self,
-        exception_types: typing.Union[
-            typing.Type[BaseException],
-            typing.Tuple[typing.Type[BaseException], ...],
-        ] = Exception,
+        exception_types: type[BaseException]
+        | tuple[type[BaseException], ...] = Exception,
     ) -> None:
         self.exception_cause_types = exception_types
 
@@ -206,8 +198,8 @@ class retry_if_exception_message(retry_if_exception):
 
     def __init__(
         self,
-        message: typing.Optional[str] = None,
-        match: typing.Union[None, str, typing.Pattern[str]] = None,
+        message: str | None = None,
+        match: None | str | typing.Pattern[str] = None,
     ) -> None:
         if message and match:
             raise TypeError(
@@ -241,8 +233,8 @@ class retry_if_not_exception_message(retry_if_exception_message):
 
     def __init__(
         self,
-        message: typing.Optional[str] = None,
-        match: typing.Union[None, str, typing.Pattern[str]] = None,
+        message: str | None = None,
+        match: None | str | typing.Pattern[str] = None,
     ) -> None:
         super().__init__(message, match)
         # invert predicate

--- a/tenacity/stop.py
+++ b/tenacity/stop.py
@@ -38,7 +38,7 @@ class stop_base(abc.ABC):
         return stop_any(self, other)
 
 
-StopBaseT = typing.Union[stop_base, typing.Callable[["RetryCallState"], bool]]
+StopBaseT = stop_base | typing.Callable[["RetryCallState"], bool]
 
 
 class stop_any(stop_base):

--- a/tenacity/tornadoweb.py
+++ b/tenacity/tornadoweb.py
@@ -15,12 +15,9 @@
 import sys
 import typing
 
-from tenacity import BaseRetrying
-from tenacity import DoAttempt
-from tenacity import DoSleep
-from tenacity import RetryCallState
-
 from tornado import gen
+
+from tenacity import BaseRetrying, DoAttempt, DoSleep, RetryCallState
 
 if typing.TYPE_CHECKING:
     from tornado.concurrent import Future
@@ -40,7 +37,7 @@ class TornadoRetrying(BaseRetrying):
     @gen.coroutine  # type: ignore[untyped-decorator]
     def __call__(
         self,
-        fn: "typing.Callable[..., typing.Union[typing.Generator[typing.Any, typing.Any, _RetValT], Future[_RetValT]]]",
+        fn: "typing.Callable[..., typing.Generator[typing.Any, typing.Any, _RetValT] | Future[_RetValT]]",
         *args: typing.Any,
         **kwargs: typing.Any,
     ) -> "typing.Generator[typing.Any, typing.Any, _RetValT]":
@@ -52,7 +49,7 @@ class TornadoRetrying(BaseRetrying):
             if isinstance(do, DoAttempt):
                 try:
                     result = yield fn(*args, **kwargs)
-                except BaseException:  # noqa: B902
+                except BaseException:
                     retry_state.set_exception(sys.exc_info())  # type: ignore[arg-type]
                 else:
                     retry_state.set_result(result)

--- a/tenacity/wait.py
+++ b/tenacity/wait.py
@@ -41,9 +41,7 @@ class wait_base(abc.ABC):
         return self.__add__(other)
 
 
-WaitBaseT = typing.Union[
-    wait_base, typing.Callable[["RetryCallState"], typing.Union[float, int]]
-]
+WaitBaseT = wait_base | typing.Callable[["RetryCallState"], float | int]
 
 
 class wait_fixed(wait_base):
@@ -189,9 +187,9 @@ class wait_exponential(wait_base):
 
     def __init__(
         self,
-        multiplier: typing.Union[int, float] = 1,
+        multiplier: int | float = 1,
         max: _utils.time_unit_type = _utils.MAX_WAIT,  # noqa
-        exp_base: typing.Union[int, float] = 2,
+        exp_base: int | float = 2,
         min: _utils.time_unit_type = 0,  # noqa
     ) -> None:
         self.multiplier = multiplier

--- a/tests/test_after.py
+++ b/tests/test_after.py
@@ -3,8 +3,10 @@ import logging
 import random
 import unittest.mock
 
-from tenacity import _utils  # noqa
-from tenacity import after_log
+from tenacity import (
+    _utils,  # noqa
+    after_log,
+)
 
 from . import test_tenacity
 

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -29,9 +29,15 @@ else:
 import pytest
 
 import tenacity
-from tenacity import AsyncRetrying, RetryError
+from tenacity import (
+    AsyncRetrying,
+    RetryError,
+    retry,
+    retry_if_exception,
+    retry_if_result,
+    stop_after_attempt,
+)
 from tenacity import asyncio as tasyncio
-from tenacity import retry, retry_if_exception, retry_if_result, stop_after_attempt
 from tenacity.wait import wait_fixed
 
 from .test_tenacity import (

--- a/tests/test_issue_478.py
+++ b/tests/test_issue_478.py
@@ -1,7 +1,6 @@
 import asyncio
 import typing
 import unittest
-
 from functools import wraps
 
 from tenacity import RetryCallState, retry
@@ -60,7 +59,7 @@ class TestIssue478(unittest.TestCase):
         except Exception as exc:
             assert str(exc) == "Error is not working"
         else:
-            assert False, "No exception caught"
+            raise AssertionError("No exception caught")
 
         assert results == [
             "Error is not working",
@@ -108,7 +107,7 @@ class TestIssue478(unittest.TestCase):
         except Exception as exc:
             assert str(exc) == "Error is not working"
         else:
-            assert False, "No exception caught"
+            raise AssertionError("No exception caught")
 
         assert results == [
             "Error is not working",

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -364,7 +364,7 @@ class TestWaitConditions(unittest.TestCase):
             )
         )
         # Test it a few time since it's random
-        for i in range(1000):
+        for _i in range(1000):
             w = r.wait(make_retry_state(1, 5))
             self.assertLess(w, 8)
             self.assertGreaterEqual(w, 5)
@@ -390,7 +390,7 @@ class TestWaitConditions(unittest.TestCase):
     def test_wait_double_sum(self):
         r = Retrying(wait=tenacity.wait_random(0, 3) + tenacity.wait_fixed(5))
         # Test it a few time since it's random
-        for i in range(1000):
+        for _i in range(1000):
             w = r.wait(make_retry_state(1, 5))
             self.assertLess(w, 8)
             self.assertGreaterEqual(w, 5)
@@ -402,7 +402,7 @@ class TestWaitConditions(unittest.TestCase):
             + tenacity.wait_fixed(5)
         )
         # Test it a few time since it's random
-        for i in range(1000):
+        for _i in range(1000):
             w = r.wait(make_retry_state(1, 5))
             self.assertLess(w, 9)
             self.assertGreaterEqual(w, 6)
@@ -1302,10 +1302,7 @@ class TestRetryWith:
 
     def test_retry_error_callback_should_be_preserved(self):
         def return_text(retry_state):
-            return "Calling {} keeps raising errors after {} attempts".format(
-                retry_state.fn.__name__,
-                retry_state.attempt_number,
-            )
+            return f"Calling {retry_state.fn.__name__} keeps raising errors after {retry_state.attempt_number} attempts"
 
         @retry(stop=tenacity.stop_after_attempt(10), retry_error_callback=return_text)
         def _retryable():
@@ -1555,7 +1552,7 @@ class TestStatistics(unittest.TestCase):
         self.assertEqual({}, _foobar.statistics)
         try:
             _foobar()
-        except Exception:  # noqa: B902
+        except Exception:
             pass
         self.assertEqual(2, _foobar.statistics["attempt_number"])
 

--- a/tests/test_tornado.py
+++ b/tests/test_tornado.py
@@ -15,11 +15,9 @@
 
 import unittest
 
-from tenacity import RetryError, retry, stop_after_attempt
-from tenacity import tornadoweb
+from tornado import gen, testing
 
-from tornado import gen
-from tornado import testing
+from tenacity import RetryError, retry, stop_after_attempt, tornadoweb
 
 from .test_tenacity import NoIOErrorAfterCount
 


### PR DESCRIPTION
Enable import sorting (I), pyupgrade (UP), and flake8-bugbear (B)
ruff rules. Ignore B008 (function calls in defaults, intentional API),
B905 (zip strict), and E501 (line length, handled by formatter).

- Auto-fix import sorting across all files
- Convert typing.Union to X | Y syntax (UP007)
- Convert typing.Optional to X | None (UP045)
- Convert typing.List/Dict to builtin generics (UP006)
- Convert .format() to f-strings (UP032)
- Rename unused loop vars to _ (B007)
- Replace assert False with raise AssertionError (B011)
- Remove stale noqa comments (B902, I100)