### PR TITLE
ci: harden release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,10 @@ on:
 jobs:
   pypi-publish:
     name: upload release to PyPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: release
     permissions:
       id-token: write
-      contents: write
     steps:
       - uses: actions/checkout@v6.0.2
         with:


### PR DESCRIPTION
- Pin runner to ubuntu-24.04 for reproducibility (matches CI)
- Drop contents:write permission (only id-token:write needed
  for PyPI trusted publishing)