### PR TITLE
fix: use typing.Self on Python 3.11+ instead of typing_extensions

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -102,7 +102,10 @@ except ImportError:
     tornado = None  # type: ignore[assignment]
 
 if t.TYPE_CHECKING:
-    from typing_extensions import Self
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 
     from . import asyncio as tasyncio
     from .retry import RetryBaseT


### PR DESCRIPTION
On Python 3.11+, Self is available in the standard typing module.
Only fall back to typing_extensions for Python 3.10 (under
TYPE_CHECKING only, so no runtime dependency added).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>