### PR TITLE
chore: bump tornado version floor to >=6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ doc = [
 ]
 test = [
     "pytest",
-    "tornado>=4.5",
+    "tornado>=6.0",
     "typeguard",
 ]
 
@@ -54,7 +54,7 @@ test = [
 dev = [
     "poethepoet",
     "pytest",
-    "tornado>=4.5",
+    "tornado>=6.0",
     "typeguard",
     "ruff",
     "mypy",


### PR DESCRIPTION
Tornado 4.x and 5.x are long EOL. Tornado 6.0 was released in
March 2019 and is the minimum version that supports Python 3.10+
(our minimum). This aligns the declared floor with reality since
older versions cannot install on supported Python versions anyway.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>