### PR TITLE
refactor: enable additional ruff rules and fix violations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,11 +103,15 @@ target-version = "py310"
 exclude = ["tenacity/_version.py"]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "UP", "B"]
+select = ["E", "F", "W", "I", "UP", "B", "C4", "FURB", "PERF", "PIE", "RET", "RUF", "SIM", "TCH"]
 ignore = [
     "B008",  # function calls in default arguments (intentional API design)
     "B905",  # zip() without strict= (not needed in existing code)
     "E501",  # line too long (formatter handles what it can)
+    "RUF003",  # ambiguous unicode characters in comments (copyright names)
+    "RUF005",  # iterable unpacking vs concatenation (less readable for tuple +)
+    "RUF012",  # mutable class default (test constant, never mutated)
+    "SIM108",  # ternary instead of if-else (less readable in context)
 ]
 
 [tool.mypy]

--- a/tenacity/_utils.py
+++ b/tenacity/_utils.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import contextlib
 import functools
 import inspect
 import sys
@@ -44,16 +45,15 @@ def find_ordinal(pos_num: int) -> str:
 
     if pos_num == 0:
         return "th"
-    elif pos_num == 1:
+    if pos_num == 1:
         return "st"
-    elif pos_num == 2:
+    if pos_num == 2:
         return "nd"
-    elif pos_num == 3:
+    if pos_num == 3:
         return "rd"
-    elif 4 <= pos_num <= 20:
+    if 4 <= pos_num <= 20:
         return "th"
-    else:
-        return find_ordinal(pos_num % 10)
+    return find_ordinal(pos_num % 10)
 
 
 def to_ordinal(pos_num: int) -> str:
@@ -69,20 +69,15 @@ def get_callback_name(cb: typing.Callable[..., typing.Any]) -> str:
     try:
         segments.append(cb.__qualname__)
     except AttributeError:
-        try:
+        with contextlib.suppress(AttributeError):
             segments.append(cb.__name__)
-        except AttributeError:
-            pass
     if not segments:
         return repr(cb)
-    else:
-        try:
-            # When running under sphinx it appears this can be none?
-            if cb.__module__:
-                segments.insert(0, cb.__module__)
-        except AttributeError:
-            pass
-        return ".".join(segments)
+    with contextlib.suppress(AttributeError):
+        # When running under sphinx it appears this can be none?
+        if cb.__module__:
+            segments.insert(0, cb.__module__)
+    return ".".join(segments)
 
 
 time_unit_type = int | float | timedelta

--- a/tenacity/asyncio/__init__.py
+++ b/tenacity/asyncio/__init__.py
@@ -32,18 +32,17 @@ from tenacity import (
     before_nothing,
 )
 
-from ..retry import RetryBaseT as SyncRetryBaseT
-
 # Import all built-in retry strategies for easier usage.
 from .retry import (
     RetryBaseT,
-    retry_all,  # noqa
-    retry_any,  # noqa
-    retry_if_exception,  # noqa
-    retry_if_result,  # noqa
+    retry_all,
+    retry_any,
+    retry_if_exception,
+    retry_if_result,
 )
 
 if t.TYPE_CHECKING:
+    from tenacity.retry import RetryBaseT as SyncRetryBaseT
     from tenacity.stop import StopBaseT
     from tenacity.wait import WaitBaseT
 
@@ -149,7 +148,7 @@ class AsyncRetrying(BaseRetrying):
             retry_state
         )
 
-    async def iter(self, retry_state: "RetryCallState") -> DoAttempt | DoSleep | t.Any:  # noqa: A003
+    async def iter(self, retry_state: "RetryCallState") -> DoAttempt | DoSleep | t.Any:
         self._begin_iter(retry_state)
         result = None
         for action in self.iter_state.actions:
@@ -169,9 +168,9 @@ class AsyncRetrying(BaseRetrying):
             do = await self.iter(retry_state=self._retry_state)
             if do is None:
                 raise StopAsyncIteration
-            elif isinstance(do, DoAttempt):
+            if isinstance(do, DoAttempt):
                 return AttemptManager(retry_state=self._retry_state)
-            elif isinstance(do, DoSleep):
+            if isinstance(do, DoSleep):
                 self._retry_state.prepare_for_next_attempt()
                 await self.sleep(do)  # type: ignore[misc]
             else:
@@ -200,10 +199,10 @@ class AsyncRetrying(BaseRetrying):
 
 
 __all__ = [
+    "AsyncRetrying",
+    "WrappedFn",
     "retry_all",
     "retry_any",
     "retry_if_exception",
     "retry_if_result",
-    "WrappedFn",
-    "AsyncRetrying",
 ]

--- a/tenacity/asyncio/retry.py
+++ b/tenacity/asyncio/retry.py
@@ -72,8 +72,7 @@ class retry_if_exception(async_retry_base):
             if exception is None:
                 raise RuntimeError("outcome failed but the exception is None")
             return await self.predicate(exception)
-        else:
-            return False
+        return False
 
 
 class retry_if_result(async_retry_base):
@@ -90,8 +89,7 @@ class retry_if_result(async_retry_base):
 
         if not retry_state.outcome.failed:
             return await self.predicate(retry_state.outcome.result())
-        else:
-            return False
+        return False
 
 
 class retry_any(async_retry_base):

--- a/tenacity/retry.py
+++ b/tenacity/retry.py
@@ -80,8 +80,7 @@ class retry_if_exception(retry_base):
             if exception is None:
                 raise RuntimeError("outcome failed but the exception is None")
             return self.predicate(exception)
-        else:
-            return False
+        return False
 
 
 class retry_if_exception_type(retry_if_exception):
@@ -173,8 +172,7 @@ class retry_if_result(retry_base):
 
         if not retry_state.outcome.failed:
             return self.predicate(retry_state.outcome.result())
-        else:
-            return False
+        return False
 
 
 class retry_if_not_result(retry_base):
@@ -189,8 +187,7 @@ class retry_if_not_result(retry_base):
 
         if not retry_state.outcome.failed:
             return not self.predicate(retry_state.outcome.result())
-        else:
-            return False
+        return False
 
 
 class retry_if_exception_message(retry_if_exception):

--- a/tenacity/wait.py
+++ b/tenacity/wait.py
@@ -66,7 +66,7 @@ class wait_random(wait_base):
 
     def __init__(
         self, min: _utils.time_unit_type = 0, max: _utils.time_unit_type = 1
-    ) -> None:  # noqa
+    ) -> None:
         self.wait_random_min = _utils.to_seconds(min)
         self.wait_random_max = _utils.to_seconds(max)
 
@@ -161,7 +161,7 @@ class wait_incrementing(wait_base):
         self,
         start: _utils.time_unit_type = 0,
         increment: _utils.time_unit_type = 100,
-        max: _utils.time_unit_type = _utils.MAX_WAIT,  # noqa
+        max: _utils.time_unit_type = _utils.MAX_WAIT,
     ) -> None:
         self.start = _utils.to_seconds(start)
         self.increment = _utils.to_seconds(increment)
@@ -188,9 +188,9 @@ class wait_exponential(wait_base):
     def __init__(
         self,
         multiplier: int | float = 1,
-        max: _utils.time_unit_type = _utils.MAX_WAIT,  # noqa
+        max: _utils.time_unit_type = _utils.MAX_WAIT,
         exp_base: int | float = 2,
-        min: _utils.time_unit_type = 0,  # noqa
+        min: _utils.time_unit_type = 0,
     ) -> None:
         self.multiplier = multiplier
         self.min = _utils.to_seconds(min)
@@ -252,7 +252,7 @@ class wait_exponential_jitter(wait_base):
     def __init__(
         self,
         initial: float = 1,
-        max: float = _utils.MAX_WAIT,  # noqa
+        max: float = _utils.MAX_WAIT,
         exp_base: float = 2,
         jitter: float = 1,
     ) -> None:

--- a/tests/test_after.py
+++ b/tests/test_after.py
@@ -4,7 +4,7 @@ import random
 import unittest.mock
 
 from tenacity import (
-    _utils,  # noqa
+    _utils,
     after_log,
 )
 


### PR DESCRIPTION
Enable C4, FURB, PERF, PIE, RET, RUF, SIM, TCH rule sets.

Key changes:
- Remove all stale noqa comments across the codebase (RUF100)
- Sort __all__ alphabetically (RUF022)
- Remove superfluous else after return/raise (RET505/RET506)
- Replace try/except/pass with contextlib.suppress (SIM105)
- Move type-only imports into TYPE_CHECKING blocks (TC001/TC003)
- Quote type expressions in typing.cast() calls (TC006)
- Use list comprehension instead of loop-append (PERF401)
- Fix Cyrillic character in docstring (RUF002)
- Remove unnecessary int() wrapping round() (RUF046)
- Replace dict() call with literal (C408)

Ignored rules:
- RUF003: ambiguous unicode in comments (copyright holder names)
- RUF005: iterable unpacking vs concatenation (less readable)
- RUF012: mutable class defaults (false positive on test fixtures)
- SIM108: ternary expressions (less readable in context)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>