### PR TITLE
fix: make LoggerProtocol compatible with logging.Logger

### DIFF
--- a/tenacity/_utils.py
+++ b/tenacity/_utils.py
@@ -33,7 +33,7 @@ class LoggerProtocol(typing.Protocol):
     """
 
     def log(
-        self, level: int, msg: str, /, *args: typing.Any, **kwargs: typing.Any
+        self, level: int, msg: str, *args: typing.Any, **kwargs: typing.Any
     ) -> typing.Any: ...
 
 


### PR DESCRIPTION
Remove the positional-only marker (/) from LoggerProtocol.log().
logging.Logger.log() defines msg as a regular parameter, so the
positional-only constraint caused mypy to reject logging.Logger
as incompatible with the protocol.

Closes #554

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>