### PR TITLE
refactor: remove unused IterState.delay_since_first_attempt field

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -114,14 +114,12 @@ class IterState:
         default_factory=list
     )
     retry_run_result: bool = False
-    delay_since_first_attempt: int = 0
     stop_run_result: bool = False
     is_explicit_retry: bool = False
 
     def reset(self) -> None:
         self.actions = []
         self.retry_run_result = False
-        self.delay_since_first_attempt = 0
         self.stop_run_result = False
         self.is_explicit_retry = False
 


### PR DESCRIPTION
This field was declared and reset but never read or written anywhere
in the codebase. The actual delay tracking uses
statistics["delay_since_first_attempt"] instead.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>