### PR TITLE
refactor: remove redundant raise before reraise()

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -413,7 +413,7 @@ class BaseRetrying(ABC):
                 fut = t.cast("Future", rs.outcome)
                 retry_exc = self.retry_error_cls(fut)
                 if self.reraise:
-                    raise retry_exc.reraise()
+                    retry_exc.reraise()
                 raise retry_exc from fut.exception()
 
             self._add_action_func(exc_check)


### PR DESCRIPTION
reraise() is typed as NoReturn and always raises internally.
The outer `raise` keyword was dead code that could never execute,
and was misleading since it suggested reraise() returns an exception
rather than raising one directly.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>