### PR TITLE
refactor: replace deprecated typing.Pattern with re.Pattern

### DIFF
--- a/tenacity/retry.py
+++ b/tenacity/retry.py
@@ -196,7 +196,7 @@ class retry_if_exception_message(retry_if_exception):
     def __init__(
         self,
         message: str | None = None,
-        match: None | str | typing.Pattern[str] = None,
+        match: None | str | re.Pattern[str] = None,
     ) -> None:
         if message and match:
             raise TypeError(
@@ -231,7 +231,7 @@ class retry_if_not_exception_message(retry_if_exception_message):
     def __init__(
         self,
         message: str | None = None,
-        match: None | str | typing.Pattern[str] = None,
+        match: None | str | re.Pattern[str] = None,
     ) -> None:
         super().__init__(message, match)
         # invert predicate


### PR DESCRIPTION
typing.Pattern has been deprecated since Python 3.9 in favor of
re.Pattern. Since we require Python >=3.10, use the standard form.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>