### PR TITLE
fix: guard against None seconds_since_start in after_log

### DIFF
--- a/tenacity/after.py
+++ b/tenacity/after.py
@@ -39,10 +39,11 @@ def after_log(
             fn_name = "<unknown>"
         else:
             fn_name = _utils.get_callback_name(retry_state.fn)
+        secs = retry_state.seconds_since_start
         logger.log(
             log_level,
             f"Finished call to '{fn_name}' "
-            f"after {sec_format % retry_state.seconds_since_start}(s), "
+            f"after {sec_format % secs if secs is not None else '?'}(s), "
             f"this was the {_utils.to_ordinal(retry_state.attempt_number)} time calling it.",
         )
 

--- a/tests/test_after.py
+++ b/tests/test_after.py
@@ -50,6 +50,29 @@ class TestAfterLogFormat(unittest.TestCase):
             f"this was the {_utils.to_ordinal(retry_state.attempt_number)} time calling it.",
         )
 
+    def test_02_none_seconds_since_start(self) -> None:
+        """Test log formatting when seconds_since_start is None."""
+        log = unittest.mock.MagicMock(spec="logging.Logger.log")
+        logger = unittest.mock.MagicMock(spec="logging.Logger", log=log)
+
+        retry_state = test_tenacity.make_retry_state(self.previous_attempt_number, 0.1)
+        retry_state.outcome_timestamp = None
+        assert retry_state.seconds_since_start is None
+
+        fun = after_log(logger=logger, log_level=self.log_level)
+        fun(retry_state)
+        fn_name = (
+            "<unknown>"
+            if retry_state.fn is None
+            else _utils.get_callback_name(retry_state.fn)
+        )
+        log.assert_called_once_with(
+            self.log_level,
+            f"Finished call to '{fn_name}' "
+            f"after ?(s), "
+            f"this was the {_utils.to_ordinal(retry_state.attempt_number)} time calling it.",
+        )
+
     def test_02_custom_sec_format(self) -> None:
         """Test log formatting with custom int format.."""
         log = unittest.mock.MagicMock(spec="logging.Logger.log")


### PR DESCRIPTION
`RetryCallState.seconds_since_start` returns None when
`outcome_timestamp` is not set. The `%` format operator in `after_log`
would crash with a TypeError in this case. Fall back to "?" when the
value is None.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>