### PR TITLE
feat: add name parameter to Retrying for meaningful log output

### DIFF
--- a/tenacity/after.py
+++ b/tenacity/after.py
@@ -34,11 +34,7 @@ def after_log(
     """After call strategy that logs to some logger the finished attempt."""
 
     def log_it(retry_state: "RetryCallState") -> None:
-        if retry_state.fn is None:
-            # NOTE(sileht): can't really happen, but we must please mypy
-            fn_name = "<unknown>"
-        else:
-            fn_name = _utils.get_callback_name(retry_state.fn)
+        fn_name = retry_state.get_fn_name()
         secs = retry_state.seconds_since_start
         logger.log(
             log_level,

--- a/tenacity/asyncio/__init__.py
+++ b/tenacity/asyncio/__init__.py
@@ -87,6 +87,7 @@ class AsyncRetrying(BaseRetrying):
         retry_error_cls: type["RetryError"] = RetryError,
         retry_error_callback: t.Callable[["RetryCallState"], t.Any | t.Awaitable[t.Any]]
         | None = None,
+        name: str | None = None,
     ) -> None:
         super().__init__(
             sleep=sleep,  # type: ignore[arg-type]
@@ -99,6 +100,7 @@ class AsyncRetrying(BaseRetrying):
             reraise=reraise,
             retry_error_cls=retry_error_cls,
             retry_error_callback=retry_error_callback,
+            name=name,
         )
 
     async def __call__(  # type: ignore[override]

--- a/tenacity/before.py
+++ b/tenacity/before.py
@@ -32,11 +32,7 @@ def before_log(
     """Before call strategy that logs to some logger the attempt."""
 
     def log_it(retry_state: "RetryCallState") -> None:
-        if retry_state.fn is None:
-            # NOTE(sileht): can't really happen, but we must please mypy
-            fn_name = "<unknown>"
-        else:
-            fn_name = _utils.get_callback_name(retry_state.fn)
+        fn_name = retry_state.get_fn_name()
         logger.log(
             log_level,
             f"Starting call to '{fn_name}', "

--- a/tenacity/before_sleep.py
+++ b/tenacity/before_sleep.py
@@ -55,11 +55,7 @@ def before_sleep_log(
             verb, value = "returned", retry_state.outcome.result()
             local_exc_info = False  # exc_info does not apply when no exception
 
-        if retry_state.fn is None:
-            # NOTE(sileht): can't really happen, but we must please mypy
-            fn_name = "<unknown>"
-        else:
-            fn_name = _utils.get_callback_name(retry_state.fn)
+        fn_name = retry_state.get_fn_name()
 
         logger.log(
             log_level,

--- a/tests/test_after.py
+++ b/tests/test_after.py
@@ -38,14 +38,9 @@ class TestAfterLogFormat(unittest.TestCase):
             logger=logger, log_level=self.log_level
         )  # use default sec_format
         fun(retry_state)
-        fn_name = (
-            "<unknown>"
-            if retry_state.fn is None
-            else _utils.get_callback_name(retry_state.fn)
-        )
         log.assert_called_once_with(
             self.log_level,
-            f"Finished call to '{fn_name}' "
+            f"Finished call to '{retry_state.get_fn_name()}' "
             f"after {sec_format % retry_state.seconds_since_start}(s), "
             f"this was the {_utils.to_ordinal(retry_state.attempt_number)} time calling it.",
         )
@@ -61,14 +56,9 @@ class TestAfterLogFormat(unittest.TestCase):
 
         fun = after_log(logger=logger, log_level=self.log_level)
         fun(retry_state)
-        fn_name = (
-            "<unknown>"
-            if retry_state.fn is None
-            else _utils.get_callback_name(retry_state.fn)
-        )
         log.assert_called_once_with(
             self.log_level,
-            f"Finished call to '{fn_name}' "
+            f"Finished call to '{retry_state.get_fn_name()}' "
             f"after ?(s), "
             f"this was the {_utils.to_ordinal(retry_state.attempt_number)} time calling it.",
         )
@@ -86,14 +76,9 @@ class TestAfterLogFormat(unittest.TestCase):
         )
         fun = after_log(logger=logger, log_level=self.log_level, sec_format=sec_format)
         fun(retry_state)
-        fn_name = (
-            "<unknown>"
-            if retry_state.fn is None
-            else _utils.get_callback_name(retry_state.fn)
-        )
         log.assert_called_once_with(
             self.log_level,
-            f"Finished call to '{fn_name}' "
+            f"Finished call to '{retry_state.get_fn_name()}' "
             f"after {sec_format % retry_state.seconds_since_start}(s), "
             f"this was the {_utils.to_ordinal(retry_state.attempt_number)} time calling it.",
         )


### PR DESCRIPTION
When using `Retrying` or `AsyncRetrying` as a context manager, log
callbacks showed '<unknown>' as the function name since no `fn` is
set. A new `name` parameter allows users to provide a meaningful
identifier:

    for attempt in Retrying(name='ws_listener', before_sleep=before_sleep_log(...)):
        with attempt:
            ...

`RetryCallState.get_fn_name()` is introduced as the single source of
truth for resolving the display name: it returns the decorated
function's qualified name when used as a decorator, falls back to
`str(retry_object)` in context manager mode. `BaseRetrying.__str__`
returns `name` if set, else '<unknown>'. The three log helpers
(before_log, after_log, before_sleep_log) all use `get_fn_name()`
instead of the repeated `fn is None` boilerplate.

Closes #273, closes #333

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>