### PR TITLE
Fix retry_if_exception_message rejecting empty string arguments

### DIFF
--- a/tenacity/retry.py
+++ b/tenacity/retry.py
@@ -198,19 +198,19 @@ class retry_if_exception_message(retry_if_exception):
         message: str | None = None,
         match: None | str | re.Pattern[str] = None,
     ) -> None:
-        if message and match:
+        if message is not None and match is not None:
             raise TypeError(
                 f"{self.__class__.__name__}() takes either 'message' or 'match', not both"
             )
 
         # set predicate
-        if message:
+        if message is not None:
 
             def message_fnc(exception: BaseException) -> bool:
                 return message == str(exception)
 
             predicate = message_fnc
-        elif match:
+        elif match is not None:
             prog = re.compile(match)
 
             def match_fnc(exception: BaseException) -> bool:


### PR DESCRIPTION
## Summary

`retry_if_exception_message(message="")` incorrectly raises `TypeError` instead of creating a predicate that matches exceptions with empty string representations.

## The Bug

The constructor uses Python truthiness checks (`if message`, `elif match`) instead of `is not None` checks. Since empty string `""` is falsy:

- `message=""` falls through to `else` and raises `TypeError`
- `match=""` falls through to `else` and raises `TypeError`
- `message="", match="foo"` silently uses `match` instead of raising the mutual exclusion error

```python
from tenacity import retry_if_exception_message

# This should match exceptions like Exception() where str(Exception()) == ""
# Instead raises: TypeError: retry_if_exception_message() missing 1 required argument 'message' or 'match'
r = retry_if_exception_message(message="")
```

The same issue affects `retry_if_not_exception_message` since it inherits the constructor.

## The Fix

Replaced `if message` / `elif match` with `if message is not None` / `elif match is not None`.
