### PR TITLE
chore: remove deprecated license classifier from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ authors = [
 ]
 classifiers = [
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
## Summary

Remove the redundant `License :: OSI Approved :: Apache Software License` classifier from `pyproject.toml`.

## Details

The project already declares `license = "Apache-2.0"` as a SPDX license expression in the `[project]` table. Starting with setuptools 77.0.0, having both a SPDX license expression and a legacy `License ::` classifier triggers a `SetuptoolsDeprecationWarning`:

```
SetuptoolsDeprecationWarning: License classifiers are deprecated.
Please consider removing the following classifiers in favor of a SPDX license expression:
    License :: OSI Approved :: Apache Software License
```

Since the SPDX expression is the modern standard (PEP 639), this PR removes the legacy classifier to silence the warning.

Closes #523

## Disclosure

This PR was authored with the assistance of Claude (LLM) to help understand the codebase and structure the implementation and description.