### PR TITLE
feat: add async context manager support to AttemptManager

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -214,6 +214,17 @@ class AttemptManager:
         self.retry_state.set_result(None)
         return None
 
+    async def __aenter__(self) -> None:
+        pass
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: t.Optional["types.TracebackType"],
+    ) -> bool | None:
+        return self.__exit__(exc_type, exc_value, traceback)
+
 
 class BaseRetrying(ABC):
     def __init__(

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -191,6 +191,21 @@ class TestContextManager(unittest.TestCase):
         assert attempts == 3
 
     @asynctest
+    async def test_async_with_attempt_manager(self) -> None:
+        """AttemptManager supports async with for use inside async for."""
+        attempts = 0
+        retrying = tasyncio.AsyncRetrying(stop=stop_after_attempt(3))
+        try:
+            async for attempt in retrying:
+                async with attempt:
+                    attempts += 1
+                    raise Exception
+        except RetryError:
+            pass
+
+        assert attempts == 3
+
+    @asynctest
     async def test_reraise(self) -> None:
         class CustomError(Exception):
             pass


### PR DESCRIPTION
AttemptManager now supports `async with` in addition to `with`,
allowing cleaner usage inside `async for` loops.

Closes #469

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>