### PR TITLE
feat: support retrying generator and async generator functions

### DIFF
--- a/tenacity/_utils.py
+++ b/tenacity/_utils.py
@@ -99,6 +99,26 @@ def is_coroutine_callable(call: typing.Callable[..., typing.Any]) -> bool:
     return inspect.iscoroutinefunction(dunder_call)
 
 
+def is_generator_callable(call: typing.Callable[..., typing.Any]) -> bool:
+    if inspect.isclass(call):
+        return False
+    if inspect.isgeneratorfunction(call):
+        return True
+    partial_call = isinstance(call, functools.partial) and call.func
+    dunder_call = partial_call or getattr(call, "__call__", None)  # noqa: B004
+    return inspect.isgeneratorfunction(dunder_call)
+
+
+def is_async_gen_callable(call: typing.Callable[..., typing.Any]) -> bool:
+    if inspect.isclass(call):
+        return False
+    if inspect.isasyncgenfunction(call):
+        return True
+    partial_call = isinstance(call, functools.partial) and call.func
+    dunder_call = partial_call or getattr(call, "__call__", None)  # noqa: B004
+    return inspect.isasyncgenfunction(dunder_call)
+
+
 def wrap_to_async_func(
     call: typing.Callable[..., typing.Any],
 ) -> typing.Callable[..., typing.Awaitable[typing.Any]]:


### PR DESCRIPTION
Fixes #63

Add retry support for sync and async generator functions. When a
generator decorated with @retry raises an exception, the retry logic
kicks in and re-calls the generator function, continuing to yield
values from the new generator.

- Add is_generator_callable() and is_async_gen_callable() detection
  utilities in _utils.py
- Add sync generator wrapper in BaseRetrying.wraps()
- Add async generator wrapper in AsyncRetrying.wraps()
- Route async generators to AsyncRetrying in retry()

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>