### PR TITLE
feat: support retrying generator and async generator functions

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -733,6 +733,45 @@ You can use alternative event loops by passing the correct sleep function:
     async def my_async_trio_function_with_sleep():
         ...
 
+Retrying generators
+~~~~~~~~~~~~~~~~~~~
+
+``retry`` works on generator and async generator functions. If the generator
+raises an exception, the retry logic re-calls the generator function from the
+start.
+
+.. code-block:: python
+
+    @retry(retry=retry_if_exception_type(ConnectionError))
+    def stream_data():
+        for item in connect_to_source():
+            yield item
+
+    for item in stream_data():
+        process(item)
+
+.. code-block:: python
+
+    @retry(retry=retry_if_exception_type(ConnectionError))
+    async def async_stream_data():
+        async for item in connect_to_source():
+            yield item
+
+    async for item in async_stream_data():
+        process(item)
+
+.. note::
+
+    On retry, the generator function is called again from the beginning. Any
+    values already yielded during a failed attempt will be yielded again. If
+    you need exactly-once delivery, you should track progress outside the
+    generator.
+
+    Also note that generators passed *as arguments* to a retried function will
+    be exhausted after the first attempt and will not be rewound automatically
+    on retry. If you need to pass a generator as an argument, consider passing a
+    factory function instead.
+
 Contribute
 ----------
 

--- a/tenacity/_utils.py
+++ b/tenacity/_utils.py
@@ -99,6 +99,26 @@ def is_coroutine_callable(call: typing.Callable[..., typing.Any]) -> bool:
     return inspect.iscoroutinefunction(dunder_call)
 
 
+def is_generator_callable(call: typing.Callable[..., typing.Any]) -> bool:
+    if inspect.isclass(call):
+        return False
+    if inspect.isgeneratorfunction(call):
+        return True
+    partial_call = isinstance(call, functools.partial) and call.func
+    dunder_call = partial_call or getattr(call, "__call__", None)  # noqa: B004
+    return inspect.isgeneratorfunction(dunder_call)
+
+
+def is_async_gen_callable(call: typing.Callable[..., typing.Any]) -> bool:
+    if inspect.isclass(call):
+        return False
+    if inspect.isasyncgenfunction(call):
+        return True
+    partial_call = isinstance(call, functools.partial) and call.func
+    dunder_call = partial_call or getattr(call, "__call__", None)  # noqa: B004
+    return inspect.isasyncgenfunction(dunder_call)
+
+
 def wrap_to_async_func(
     call: typing.Callable[..., typing.Any],
 ) -> typing.Callable[..., typing.Awaitable[typing.Any]]:


### PR DESCRIPTION
Fixes #63
Fixes #64
Fixes #66
Fixes #138

Add retry support for sync and async generator functions. When a
generator decorated with @retry raises an exception, the retry logic
kicks in and re-calls the generator function, continuing to yield
values from the new generator.

- Add is_generator_callable() and is_async_gen_callable() detection
  utilities in _utils.py
- Add sync generator wrapper in BaseRetrying.wraps()
- Add async generator wrapper in AsyncRetrying.wraps()
- Route async generators to AsyncRetrying in retry()
- Document generator retry behavior and caveats

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>