### PR TITLE
Make sleep behavior consistent across retry variants

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -219,7 +219,7 @@ class AttemptManager:
 class BaseRetrying(ABC):
     def __init__(
         self,
-        sleep: t.Callable[[t.Union[int, float]], None] = sleep,
+        sleep: t.Union[t.Callable[[t.Union[int, float]], None], object] = _unset,
         stop: "StopBaseT" = stop_never,
         wait: "WaitBaseT" = wait_none(),
         retry: "RetryBaseT" = retry_if_exception_type(),
@@ -230,6 +230,9 @@ class BaseRetrying(ABC):
         retry_error_cls: t.Type[RetryError] = RetryError,
         retry_error_callback: t.Optional[t.Callable[["RetryCallState"], t.Any]] = None,
     ):
+        if sleep is _unset:
+            from . import nap
+            sleep = nap.sleep
         self.sleep = sleep
         self.stop = stop
         self.wait = wait
@@ -429,7 +432,7 @@ class BaseRetrying(ABC):
 
         self._add_action_func(next_action)
 
-        if self.before_sleep is not None:
+        if self.before_sleep is not None and self.sleep is not None:
             self._add_action_func(self.before_sleep)
 
         self._add_action_func(lambda rs: DoSleep(rs.upcoming_sleep))
@@ -444,7 +447,8 @@ class BaseRetrying(ABC):
                 yield AttemptManager(retry_state=retry_state)
             elif isinstance(do, DoSleep):
                 retry_state.prepare_for_next_attempt()
-                self.sleep(do)
+                if self.sleep is not None:
+                    self.sleep(do)
             else:
                 break
 
@@ -481,7 +485,8 @@ class Retrying(BaseRetrying):
                     retry_state.set_result(result)
             elif isinstance(do, DoSleep):
                 retry_state.prepare_for_next_attempt()
-                self.sleep(do)
+                if self.sleep is not None:
+                    self.sleep(do)
             else:
                 return do  # type: ignore[no-any-return]
 

--- a/tenacity/_utils.py
+++ b/tenacity/_utils.py
@@ -104,10 +104,14 @@ def is_coroutine_callable(call: typing.Callable[..., typing.Any]) -> bool:
 def wrap_to_async_func(
     call: typing.Callable[..., typing.Any],
 ) -> typing.Callable[..., typing.Awaitable[typing.Any]]:
-    if is_coroutine_callable(call):
-        return call
+    async def resolve_awaitable(
+        result: typing.Any,
+    ) -> typing.Any:
+        while inspect.isawaitable(result):
+            result = await result
+        return result
 
     async def inner(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
-        return call(*args, **kwargs)
+        return await resolve_awaitable(call(*args, **kwargs))
 
     return inner

--- a/tenacity/asyncio/__init__.py
+++ b/tenacity/asyncio/__init__.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 import functools
+import inspect
 import sys
 import typing as t
 
@@ -67,9 +68,10 @@ def _portable_async_sleep(seconds: float) -> t.Awaitable[None]:
 class AsyncRetrying(BaseRetrying):
     def __init__(
         self,
-        sleep: t.Callable[
-            [t.Union[int, float]], t.Union[None, t.Awaitable[None]]
-        ] = _portable_async_sleep,
+        sleep: t.Union[
+            t.Callable[[t.Union[int, float]], t.Union[None, t.Awaitable[None]]],
+            object,
+        ] = tenacity._unset,
         stop: "StopBaseT" = tenacity.stop.stop_never,
         wait: "WaitBaseT" = tenacity.wait.wait_none(),
         retry: "t.Union[SyncRetryBaseT, RetryBaseT]" = tenacity.retry_if_exception_type(),
@@ -88,6 +90,8 @@ class AsyncRetrying(BaseRetrying):
             t.Callable[["RetryCallState"], t.Union[t.Any, t.Awaitable[t.Any]]]
         ] = None,
     ) -> None:
+        if sleep is tenacity._unset:
+            sleep = _portable_async_sleep
         super().__init__(
             sleep=sleep,  # type: ignore[arg-type]
             stop=stop,
@@ -118,12 +122,21 @@ class AsyncRetrying(BaseRetrying):
                     retry_state.set_result(result)
             elif isinstance(do, DoSleep):
                 retry_state.prepare_for_next_attempt()
-                await self.sleep(do)  # type: ignore[misc]
+                if self.sleep is not None:
+                    await self.sleep(do)  # type: ignore[misc]
             else:
                 return do  # type: ignore[no-any-return]
 
+    async def _resolve_awaitable(self, value: t.Any) -> t.Any:
+        while inspect.isawaitable(value):
+            value = await value
+        return value
+
     def _add_action_func(self, fn: t.Callable[..., t.Any]) -> None:
-        self.iter_state.actions.append(_utils.wrap_to_async_func(fn))
+        async def wrapped_action(retry_state: "RetryCallState") -> t.Any:
+            return await self._resolve_awaitable(fn(retry_state))
+
+        self.iter_state.actions.append(wrapped_action)
 
     async def _run_retry(self, retry_state: "RetryCallState") -> None:  # type: ignore[override]
         self.iter_state.retry_run_result = await _utils.wrap_to_async_func(self.retry)(
@@ -132,7 +145,7 @@ class AsyncRetrying(BaseRetrying):
 
     async def _run_wait(self, retry_state: "RetryCallState") -> None:  # type: ignore[override]
         if self.wait:
-            sleep = await _utils.wrap_to_async_func(self.wait)(retry_state)
+            sleep = await self._resolve_awaitable(self.wait(retry_state))
         else:
             sleep = 0.0
 
@@ -170,7 +183,8 @@ class AsyncRetrying(BaseRetrying):
                 return AttemptManager(retry_state=self._retry_state)
             elif isinstance(do, DoSleep):
                 self._retry_state.prepare_for_next_attempt()
-                await self.sleep(do)  # type: ignore[misc]
+                if self.sleep is not None:
+                    await self.sleep(do)  # type: ignore[misc]
             else:
                 raise StopAsyncIteration
 

--- a/tenacity/tornadoweb.py
+++ b/tenacity/tornadoweb.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import sys
 import typing
 
+import tenacity
 from tenacity import BaseRetrying
 from tenacity import DoAttempt
 from tenacity import DoSleep
@@ -31,11 +33,66 @@ _RetValT = typing.TypeVar("_RetValT")
 class TornadoRetrying(BaseRetrying):
     def __init__(
         self,
-        sleep: "typing.Callable[[float], Future[None]]" = gen.sleep,
+        sleep: "typing.Union[typing.Callable[[float], Future[None]], object]" = tenacity._unset,
         **kwargs: typing.Any,
     ) -> None:
-        super().__init__(**kwargs)
-        self.sleep = sleep
+        if sleep is tenacity._unset:
+            sleep = gen.sleep
+        super().__init__(sleep=sleep, **kwargs)
+
+    @staticmethod
+    def _is_awaitable(value: typing.Any) -> bool:
+        return gen.is_future(value) or inspect.isawaitable(value)
+
+    @staticmethod
+    def _convert_awaitable(value: typing.Any) -> typing.Any:
+        if gen.is_future(value) or inspect.isawaitable(value):
+            return gen.convert_yielded(value)
+        return value
+
+    @gen.coroutine  # type: ignore[untyped-decorator]
+    def _resolve_awaitable(
+        self, value: typing.Any
+    ) -> "typing.Generator[typing.Any, typing.Any, typing.Any]":
+        while self._is_awaitable(value):
+            value = yield self._convert_awaitable(value)
+        raise gen.Return(value)
+
+    @gen.coroutine  # type: ignore[untyped-decorator]
+    def _run_retry(
+        self, retry_state: "RetryCallState"
+    ) -> "typing.Generator[typing.Any, typing.Any, None]":  # type: ignore[override]
+        retry_result = self.retry(retry_state)
+        retry_result = yield self._resolve_awaitable(retry_result)
+        self.iter_state.retry_run_result = retry_result
+
+    @gen.coroutine  # type: ignore[untyped-decorator]
+    def _run_wait(self, retry_state: "RetryCallState") -> "typing.Generator[typing.Any, typing.Any, None]":  # type: ignore[override]
+        if self.wait:
+            sleep = self.wait(retry_state)
+            sleep = yield self._resolve_awaitable(sleep)
+        else:
+            sleep = 0.0
+        retry_state.upcoming_sleep = sleep
+
+    @gen.coroutine  # type: ignore[untyped-decorator]
+    def _run_stop(
+        self, retry_state: "RetryCallState"
+    ) -> "typing.Generator[typing.Any, typing.Any, None]":  # type: ignore[override]
+        self.statistics["delay_since_first_attempt"] = retry_state.seconds_since_start
+        stop_result = self.stop(retry_state)
+        stop_result = yield self._resolve_awaitable(stop_result)
+        self.iter_state.stop_run_result = stop_result
+
+    @gen.coroutine  # type: ignore[untyped-decorator]
+    def iter(  # type: ignore[override]
+        self, retry_state: "RetryCallState"
+    ) -> "typing.Generator[typing.Any, typing.Any, typing.Any]":
+        self._begin_iter(retry_state)
+        result = None
+        for action in self.iter_state.actions:
+            result = yield self._resolve_awaitable(action(retry_state))
+        raise gen.Return(result)
 
     @gen.coroutine  # type: ignore[untyped-decorator]
     def __call__(
@@ -48,7 +105,7 @@ class TornadoRetrying(BaseRetrying):
 
         retry_state = RetryCallState(retry_object=self, fn=fn, args=args, kwargs=kwargs)
         while True:
-            do = self.iter(retry_state=retry_state)
+            do = yield self.iter(retry_state=retry_state)
             if isinstance(do, DoAttempt):
                 try:
                     result = yield fn(*args, **kwargs)
@@ -58,6 +115,8 @@ class TornadoRetrying(BaseRetrying):
                     retry_state.set_result(result)
             elif isinstance(do, DoSleep):
                 retry_state.prepare_for_next_attempt()
-                yield self.sleep(do)
+                if self.sleep is not None:
+                    sleep_result = self.sleep(do)
+                    yield self._resolve_awaitable(sleep_result)
             else:
                 raise gen.Return(do)

--- a/test_1.sh
+++ b/test_1.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -e
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 {base|new}"
+    exit 1
+fi
+
+PYTHON_BIN=
+for candidate in py.exe py python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+        if "$candidate" -c "import pytest, tenacity" >/dev/null 2>&1; then
+            PYTHON_BIN="$candidate"
+            break
+        fi
+    fi
+done
+
+if [ -z "$PYTHON_BIN" ]; then
+    echo "No python interpreter found with pytest and tenacity installed"
+    exit 1
+fi
+
+case "$1" in
+    base)
+        "$PYTHON_BIN" -m pytest tests/test_tenacity.py::TestMockingSleep::test_decorated tests/test_tenacity.py::TestMockingSleep::test_decorated_retry_with -x -q --tb=short
+        ;;
+    new)
+        "$PYTHON_BIN" -m pytest tests/test_sleep_patchable.py -x -q --tb=short
+        ;;
+    *)
+        echo "Usage: $0 {base|new}"
+        exit 1
+        ;;
+esac

--- a/tests/test_sleep_patchable.py
+++ b/tests/test_sleep_patchable.py
@@ -1,0 +1,1130 @@
+import asyncio
+import functools
+import unittest
+
+import tenacity
+from tenacity import RetryError
+from tenacity import Retrying
+from tenacity import retry
+from tenacity.asyncio import AsyncRetrying
+from tenacity.stop import stop_after_attempt
+from tenacity.wait import wait_fixed
+from tenacity.wait import wait_none
+
+try:
+    from tornado import gen
+    from tornado.ioloop import IOLoop
+    from tenacity.tornadoweb import TornadoRetrying
+
+    HAS_TORNADO = True
+except ImportError:
+    HAS_TORNADO = False
+
+
+def asynctest(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        loop = asyncio.get_event_loop_policy().new_event_loop()
+        try:
+            return loop.run_until_complete(fn(*args, **kwargs))
+        finally:
+            loop.close()
+
+    return wrapper
+
+
+class C1:
+    def __init__(self):
+        self.v = []
+
+    def __call__(self, x):
+        self.v.append(float(x))
+
+
+class C2:
+    def __init__(self):
+        self.v = []
+
+    async def __call__(self, x):
+        self.v.append(float(x))
+
+
+def a1(v1, t1, value=None, error=None):
+    async def f1():
+        v1.append(t1)
+        if error is not None:
+            raise error
+        return value
+
+    async def f2():
+        return f1()
+
+    return f2()
+
+
+if HAS_TORNADO:
+
+    def t1(v1, t2, value=None, error=None):
+        @gen.coroutine
+        def f1():
+            v1.append(t2)
+            if error is not None:
+                raise error
+            raise gen.Return(value)
+
+        @gen.coroutine
+        def f2():
+            raise gen.Return(f1())
+
+        return f2()
+
+
+class TestA(unittest.TestCase):
+    def setUp(self):
+        self._old_sleep = tenacity.nap.sleep
+
+    def tearDown(self):
+        tenacity.nap.sleep = self._old_sleep
+
+    @staticmethod
+    def _fail():
+        raise ValueError("x")
+
+    def test_behavior_1(self):
+        c1 = C1()
+        c2 = C1()
+
+        tenacity.nap.sleep = c1
+        r1 = Retrying(wait=wait_fixed(1), stop=stop_after_attempt(3))
+
+        tenacity.nap.sleep = c2
+        r2 = Retrying(wait=wait_fixed(1), stop=stop_after_attempt(3))
+
+        with self.assertRaises(RetryError):
+            r1(self._fail)
+        with self.assertRaises(RetryError):
+            r2(self._fail)
+
+        self.assertEqual(c1.v, [1.0, 1.0])
+        self.assertEqual(c2.v, [1.0, 1.0])
+
+    def test_behavior_2(self):
+        c1 = C1()
+        c2 = C1()
+
+        tenacity.nap.sleep = c1
+        r1 = Retrying(sleep=c2, wait=wait_fixed(2), stop=stop_after_attempt(3))
+
+        with self.assertRaises(RetryError):
+            r1(self._fail)
+
+        self.assertEqual(c1.v, [])
+        self.assertEqual(c2.v, [2.0, 2.0])
+
+    def test_behavior_3(self):
+        c1 = C1()
+        c2 = C1()
+
+        tenacity.nap.sleep = c1
+
+        @retry(wait=wait_fixed(3), stop=stop_after_attempt(3))
+        def f1():
+            raise ValueError("y")
+
+        r1 = f1.retry.copy()
+        f2 = f1.retry_with(stop=stop_after_attempt(3))
+
+        tenacity.nap.sleep = c2
+
+        with self.assertRaises(RetryError):
+            r1(self._fail)
+        with self.assertRaises(RetryError):
+            f2()
+
+        self.assertEqual(c1.v, [3.0, 3.0, 3.0, 3.0])
+        self.assertEqual(c2.v, [])
+
+    def test_behavior_4(self):
+        v1 = []
+        v2 = []
+
+        def f1(s1):
+            v1.append(s1.attempt_number)
+            return 4
+
+        def f2(s1):
+            v2.append(s1.attempt_number)
+
+        r1 = Retrying(
+            sleep=None,
+            wait=f1,
+            stop=stop_after_attempt(4),
+            before_sleep=f2,
+        )
+        n1 = {"v": 0}
+
+        def f3():
+            n1["v"] += 1
+            if n1["v"] < 4:
+                raise ValueError("z")
+            return "ok"
+
+        out = r1(f3)
+        self.assertEqual(out, "ok")
+        self.assertEqual(n1["v"], 4)
+        self.assertEqual(v1, [1, 2, 3])
+        self.assertEqual(v2, [])
+        self.assertAlmostEqual(r1.statistics["idle_for"], 12.0, places=5)
+
+    def test_behavior_5(self):
+        c1 = C1()
+
+        v1 = []
+
+        def f1(s1):
+            v1.append(s1.attempt_number)
+
+        r1 = Retrying(
+            sleep=c1,
+            wait=wait_fixed(2),
+            stop=stop_after_attempt(3),
+            before_sleep=f1,
+        )
+        r2 = r1.copy(sleep=None)
+        n1 = {"v": 0}
+
+        def f2():
+            n1["v"] += 1
+            if n1["v"] < 3:
+                raise ValueError("x")
+            return "ok"
+
+        out1 = r2(f2)
+        self.assertEqual(out1, "ok")
+        self.assertEqual(c1.v, [])
+        self.assertEqual(v1, [])
+        self.assertAlmostEqual(r2.statistics["idle_for"], 4.0, places=5)
+
+        v2 = []
+
+        def f3(s1):
+            v2.append(s1.attempt_number)
+
+        n2 = {"v": 0}
+
+        @retry(
+            sleep=c1,
+            wait=wait_fixed(2),
+            stop=stop_after_attempt(3),
+            before_sleep=f3,
+        )
+        def f4():
+            n2["v"] += 1
+            if n2["v"] < 3:
+                raise ValueError("x")
+            return "ok"
+
+        f5 = f4.retry_with(sleep=None, wait=wait_fixed(2), stop=stop_after_attempt(3))
+        out2 = f5()
+
+        self.assertEqual(out2, "ok")
+        self.assertEqual(c1.v, [])
+        self.assertEqual(v2, [])
+        self.assertAlmostEqual(f5.statistics["idle_for"], 4.0, places=5)
+
+
+class TestB(unittest.TestCase):
+    def setUp(self):
+        self._old_sleep = tenacity.nap.sleep
+
+    def tearDown(self):
+        tenacity.nap.sleep = self._old_sleep
+
+    @asynctest
+    async def test_behavior_6(self):
+        c1 = C1()
+        tenacity.nap.sleep = c1
+
+        r1 = AsyncRetrying(wait=wait_fixed(0.1), stop=stop_after_attempt(3))
+        n1 = {"v": 0}
+
+        async def f1():
+            n1["v"] += 1
+            if n1["v"] < 3:
+                raise ValueError("x")
+            return "ok"
+
+        out = await r1(f1)
+        self.assertEqual(out, "ok")
+        self.assertEqual(n1["v"], 3)
+        self.assertEqual(c1.v, [])
+        self.assertAlmostEqual(r1.statistics["idle_for"], 0.2, places=4)
+
+    @asynctest
+    async def test_behavior_7(self):
+        v1 = []
+        n1 = {"v": 0}
+
+        def f1(s1):
+            return a1(v1, ("w", s1.attempt_number), value=2.0)
+
+        def f2(s1):
+            return a1(v1, ("b", s1.attempt_number), value=None)
+
+        r1 = AsyncRetrying(
+            sleep=None,
+            wait=f1,
+            stop=stop_after_attempt(3),
+            before_sleep=f2,
+        )
+
+        async def f3():
+            n1["v"] += 1
+            if n1["v"] < 3:
+                raise ValueError("x")
+            return "ok"
+
+        out = await r1(f3)
+        self.assertEqual(out, "ok")
+        self.assertEqual(v1, [("w", 1), ("w", 2)])
+        self.assertAlmostEqual(r1.statistics["idle_for"], 4.0, places=5)
+
+    @asynctest
+    async def test_behavior_8(self):
+        v1 = []
+        n1 = {"v": 0}
+
+        def f1(s1):
+            return a1(v1, ("x", s1.attempt_number), value=None)
+
+        def f2(s1):
+            return a1(v1, ("y", s1.attempt_number), value=None)
+
+        r1 = AsyncRetrying(
+            sleep=None,
+            wait=wait_none(),
+            stop=stop_after_attempt(3),
+            before=f1,
+            after=f2,
+        )
+
+        async def f3():
+            n1["v"] += 1
+            if n1["v"] < 3:
+                raise ValueError("x")
+            return "ok"
+
+        out = await r1(f3)
+        self.assertEqual(out, "ok")
+        self.assertEqual(v1, [("x", 1), ("y", 1), ("x", 2), ("y", 2), ("x", 3)])
+
+    @asynctest
+    async def test_behavior_9(self):
+        v1 = []
+
+        def f1(s1):
+            return a1(v1, ("r", s1.attempt_number), value=True)
+
+        def f2(s1):
+            return a1(v1, ("s", s1.attempt_number), value=(s1.attempt_number >= 3))
+
+        def f3(s1):
+            return a1(v1, ("e", s1.attempt_number), value="ok")
+
+        r1 = AsyncRetrying(
+            sleep=None,
+            wait=wait_none(),
+            retry=f1,
+            stop=f2,
+            retry_error_callback=f3,
+        )
+
+        async def f4():
+            raise ValueError("x")
+
+        out = await r1(f4)
+        self.assertEqual(out, "ok")
+        self.assertEqual(
+            v1,
+            [
+                ("r", 1),
+                ("s", 1),
+                ("r", 2),
+                ("s", 2),
+                ("r", 3),
+                ("s", 3),
+                ("e", 3),
+            ],
+        )
+
+    @asynctest
+    async def test_behavior_10(self):
+        v1 = []
+
+        def f1(s1):
+            return a1(v1, ("y", s1.attempt_number), value=None)
+
+        def f2(s1):
+            return a1(v1, ("e", s1.attempt_number), value="bad")
+
+        r1 = AsyncRetrying(
+            sleep=None,
+            wait=wait_none(),
+            stop=stop_after_attempt(3),
+            after=f1,
+            retry_error_callback=f2,
+        )
+
+        async def f3():
+            raise ValueError("x")
+
+        out = await r1(f3)
+        self.assertEqual(out, "bad")
+        self.assertEqual(v1, [("y", 1), ("y", 2), ("y", 3), ("e", 3)])
+
+
+@unittest.skipUnless(HAS_TORNADO, "tornado not installed")
+class TestC(unittest.TestCase):
+    def setUp(self):
+        self._old_sleep = tenacity.nap.sleep
+
+    def tearDown(self):
+        tenacity.nap.sleep = self._old_sleep
+
+    def test_behavior_11(self):
+        c1 = C1()
+        tenacity.nap.sleep = c1
+
+        r1 = TornadoRetrying(wait=wait_fixed(0.1), stop=stop_after_attempt(3))
+        n1 = {"v": 0}
+
+        @gen.coroutine
+        def f1():
+            n1["v"] += 1
+            if n1["v"] < 3:
+                raise ValueError("x")
+            raise gen.Return("ok")
+
+        out = IOLoop().run_sync(lambda: r1(f1))
+        self.assertEqual(out, "ok")
+        self.assertEqual(n1["v"], 3)
+        self.assertEqual(c1.v, [])
+        self.assertAlmostEqual(r1.statistics["idle_for"], 0.2, places=4)
+
+    def test_behavior_12(self):
+        v1 = []
+        n1 = {"v": 0}
+
+        def f1(s1):
+            return t1(v1, ("w", s1.attempt_number), value=2.0)
+
+        def f2(s1):
+            return t1(v1, ("b", s1.attempt_number), value=None)
+
+        r1 = TornadoRetrying(
+            sleep=None,
+            wait=f1,
+            stop=stop_after_attempt(3),
+            before_sleep=f2,
+        )
+
+        @gen.coroutine
+        def f3():
+            n1["v"] += 1
+            if n1["v"] < 3:
+                raise ValueError("x")
+            raise gen.Return("ok")
+
+        out = IOLoop().run_sync(lambda: r1(f3))
+        self.assertEqual(out, "ok")
+        self.assertEqual(v1, [("w", 1), ("w", 2)])
+        self.assertAlmostEqual(r1.statistics["idle_for"], 4.0, places=5)
+
+    def test_behavior_13(self):
+        v1 = []
+        n1 = {"v": 0}
+
+        def f1(s1):
+            return t1(v1, ("x", s1.attempt_number), value=None)
+
+        def f2(s1):
+            return t1(v1, ("y", s1.attempt_number), value=None)
+
+        r1 = TornadoRetrying(
+            sleep=None,
+            wait=wait_none(),
+            stop=stop_after_attempt(3),
+            before=f1,
+            after=f2,
+        )
+
+        @gen.coroutine
+        def f3():
+            n1["v"] += 1
+            if n1["v"] < 3:
+                raise ValueError("x")
+            raise gen.Return("ok")
+
+        out = IOLoop().run_sync(lambda: r1(f3))
+        self.assertEqual(out, "ok")
+        self.assertEqual(v1, [("x", 1), ("y", 1), ("x", 2), ("y", 2), ("x", 3)])
+
+    def test_behavior_14(self):
+        v1 = []
+
+        def f1(s1):
+            return t1(v1, ("r", s1.attempt_number), value=True)
+
+        def f2(s1):
+            return t1(v1, ("s", s1.attempt_number), value=(s1.attempt_number >= 3))
+
+        def f3(s1):
+            return t1(v1, ("e", s1.attempt_number), value="ok")
+
+        r1 = TornadoRetrying(
+            sleep=None,
+            wait=wait_none(),
+            retry=f1,
+            stop=f2,
+            retry_error_callback=f3,
+        )
+
+        @gen.coroutine
+        def f4():
+            raise ValueError("x")
+
+        out = IOLoop().run_sync(lambda: r1(f4))
+        self.assertEqual(out, "ok")
+        self.assertEqual(
+            v1,
+            [
+                ("r", 1),
+                ("s", 1),
+                ("r", 2),
+                ("s", 2),
+                ("r", 3),
+                ("s", 3),
+                ("e", 3),
+            ],
+        )
+
+    def test_behavior_15(self):
+        v1 = []
+
+        def f1(s1):
+            return t1(v1, ("y", s1.attempt_number), value=None)
+
+        def f2(s1):
+            return t1(v1, ("e", s1.attempt_number), value="bad")
+
+        r1 = TornadoRetrying(
+            sleep=None,
+            wait=wait_none(),
+            stop=stop_after_attempt(3),
+            after=f1,
+            retry_error_callback=f2,
+        )
+
+        @gen.coroutine
+        def f3():
+            raise ValueError("x")
+
+        out = IOLoop().run_sync(lambda: r1(f3))
+        self.assertEqual(out, "bad")
+        self.assertEqual(v1, [("y", 1), ("y", 2), ("y", 3), ("e", 3)])
+
+
+class TestD(unittest.TestCase):
+    def setUp(self):
+        self._old_sleep = tenacity.nap.sleep
+
+    def tearDown(self):
+        tenacity.nap.sleep = self._old_sleep
+
+    @staticmethod
+    def _fail():
+        raise ValueError("x")
+
+    def test_behavior_16(self):
+        c1 = C1()
+        c2 = C1()
+        tenacity.nap.sleep = c1
+        r1 = Retrying(wait=wait_fixed(1), stop=stop_after_attempt(2))
+        tenacity.nap.sleep = c2
+        with self.assertRaises(RetryError):
+            r1(self._fail)
+        self.assertEqual(c1.v, [1.0])
+        self.assertEqual(c2.v, [])
+
+    def test_behavior_17(self):
+        c1 = C1()
+        r1 = Retrying(sleep=c1, wait=wait_fixed(1), stop=stop_after_attempt(2))
+        r2 = r1.copy()
+        with self.assertRaises(RetryError):
+            r2(self._fail)
+        self.assertEqual(c1.v, [1.0])
+
+    def test_behavior_18(self):
+        c1 = C1()
+
+        @retry(sleep=c1, wait=wait_fixed(1), stop=stop_after_attempt(2))
+        def f1():
+            raise ValueError("x")
+
+        f2 = f1.retry_with(stop=stop_after_attempt(2))
+        with self.assertRaises(RetryError):
+            f2()
+        self.assertEqual(c1.v, [1.0])
+
+    def test_behavior_19(self):
+        seen = []
+
+        def wait_fn(retry_state):
+            seen.append(retry_state.attempt_number)
+            return 1.5
+
+        r1 = Retrying(sleep=None, wait=wait_fn, stop=stop_after_attempt(3))
+        n1 = {"v": 0}
+
+        def f1():
+            n1["v"] += 1
+            if n1["v"] < 3:
+                raise ValueError("x")
+            return "ok"
+
+        out = r1(f1)
+        self.assertEqual(out, "ok")
+        self.assertEqual(seen, [1, 2])
+        self.assertAlmostEqual(r1.statistics["idle_for"], 3.0, places=5)
+
+    def test_behavior_20(self):
+        c1 = C1()
+        seen = []
+
+        def before_sleep(_):
+            seen.append("called")
+
+        @retry(sleep=c1, wait=wait_fixed(2), stop=stop_after_attempt(3), before_sleep=before_sleep)
+        def f1():
+            raise ValueError("x")
+
+        f2 = f1.retry_with(sleep=None, stop=stop_after_attempt(3), wait=wait_fixed(2))
+        with self.assertRaises(RetryError):
+            f2()
+        self.assertEqual(c1.v, [])
+        self.assertEqual(seen, [])
+        self.assertAlmostEqual(f2.statistics["idle_for"], 4.0, places=5)
+
+    def test_behavior_21(self):
+        c1 = C1()
+        seen = []
+
+        def before_sleep(retry_state):
+            seen.append(retry_state.attempt_number)
+
+        r1 = Retrying(sleep=c1, wait=wait_fixed(1), stop=stop_after_attempt(3), before_sleep=before_sleep)
+        with self.assertRaises(RetryError):
+            r1(self._fail)
+        self.assertEqual(seen, [1, 2])
+
+    def test_behavior_22(self):
+        seen = []
+
+        def before_sleep(retry_state):
+            seen.append(retry_state.attempt_number)
+
+        r1 = Retrying(sleep=None, wait=wait_fixed(1), stop=stop_after_attempt(3), before_sleep=before_sleep)
+        with self.assertRaises(RetryError):
+            r1(self._fail)
+        self.assertEqual(seen, [])
+
+    def test_behavior_23(self):
+        c1 = C1()
+        c2 = C1()
+        tenacity.nap.sleep = c1
+
+        @retry(wait=wait_fixed(1), stop=stop_after_attempt(2))
+        def f1():
+            raise ValueError("x")
+
+        tenacity.nap.sleep = c2
+        with self.assertRaises(RetryError):
+            f1()
+        self.assertEqual(c1.v, [1.0])
+        self.assertEqual(c2.v, [])
+
+    def test_behavior_24(self):
+        c1 = C1()
+        c2 = C1()
+        tenacity.nap.sleep = c1
+
+        @retry(wait=wait_fixed(1), stop=stop_after_attempt(2))
+        def f1():
+            raise ValueError("x")
+
+        tenacity.nap.sleep = c2
+
+        @retry(wait=wait_fixed(1), stop=stop_after_attempt(2))
+        def f2():
+            raise ValueError("x")
+
+        with self.assertRaises(RetryError):
+            f1()
+        with self.assertRaises(RetryError):
+            f2()
+        self.assertEqual(c1.v, [1.0])
+        self.assertEqual(c2.v, [1.0])
+
+    def test_behavior_25(self):
+        c1 = C1()
+        tenacity.nap.sleep = c1
+
+        @retry(wait=wait_fixed(2), stop=stop_after_attempt(3))
+        def f1():
+            raise ValueError("x")
+
+        f2 = f1.retry_with(stop=stop_after_attempt(3))
+        with self.assertRaises(RetryError):
+            f2()
+        self.assertEqual(c1.v, [2.0, 2.0])
+
+
+class TestE(unittest.TestCase):
+    def setUp(self):
+        self._old_sleep = tenacity.nap.sleep
+
+    def tearDown(self):
+        tenacity.nap.sleep = self._old_sleep
+
+    @asynctest
+    async def test_behavior_26(self):
+        v1 = []
+
+        def f1(s1):
+            return a1(v1, ("b", s1.attempt_number), value=None)
+
+        r1 = AsyncRetrying(sleep=None, wait=wait_none(), stop=stop_after_attempt(2), before=f1)
+        n1 = {"v": 0}
+
+        async def f2():
+            n1["v"] += 1
+            if n1["v"] < 2:
+                raise ValueError("x")
+            return "ok"
+
+        out = await r1(f2)
+        self.assertEqual(out, "ok")
+        self.assertEqual(v1, [("b", 1), ("b", 2)])
+
+    @asynctest
+    async def test_behavior_27(self):
+        v1 = []
+
+        def f1(s1):
+            return a1(v1, ("a", s1.attempt_number), value=None)
+
+        r1 = AsyncRetrying(sleep=None, wait=wait_none(), stop=stop_after_attempt(2), after=f1)
+
+        async def f2():
+            raise ValueError("x")
+
+        with self.assertRaises(RetryError):
+            await r1(f2)
+        self.assertEqual(v1, [("a", 1), ("a", 2)])
+
+    @asynctest
+    async def test_behavior_28(self):
+        calls = []
+
+        def f1(s1):
+            calls.append(s1.attempt_number)
+            return a1([], ("w", s1.attempt_number), value=1.25)
+
+        r1 = AsyncRetrying(sleep=None, wait=f1, stop=stop_after_attempt(3))
+        n1 = {"v": 0}
+
+        async def f2():
+            n1["v"] += 1
+            if n1["v"] < 3:
+                raise ValueError("x")
+            return "ok"
+
+        out = await r1(f2)
+        self.assertEqual(out, "ok")
+        self.assertEqual(calls, [1, 2])
+        self.assertAlmostEqual(r1.statistics["idle_for"], 2.5, places=5)
+
+    @asynctest
+    async def test_behavior_29(self):
+        v1 = []
+        c1 = C2()
+
+        def f1(s1):
+            return a1(v1, ("bs", s1.attempt_number), value=None)
+
+        r1 = AsyncRetrying(sleep=c1, wait=wait_fixed(0.5), stop=stop_after_attempt(3), before_sleep=f1)
+        n1 = {"v": 0}
+
+        async def f2():
+            n1["v"] += 1
+            if n1["v"] < 3:
+                raise ValueError("x")
+            return "ok"
+
+        out = await r1(f2)
+        self.assertEqual(out, "ok")
+        self.assertEqual(v1, [("bs", 1), ("bs", 2)])
+        self.assertEqual(c1.v, [0.5, 0.5])
+
+    @asynctest
+    async def test_behavior_30(self):
+        v1 = []
+
+        def f1(s1):
+            return a1(v1, ("r", s1.attempt_number), value=False)
+
+        r1 = AsyncRetrying(sleep=None, wait=wait_none(), retry=f1, stop=stop_after_attempt(5))
+
+        async def f2():
+            raise ValueError("x")
+
+        with self.assertRaises(ValueError):
+            await r1(f2)
+        self.assertEqual(v1, [("r", 1)])
+
+    @asynctest
+    async def test_behavior_31(self):
+        v1 = []
+
+        def f1(s1):
+            return a1(v1, ("s", s1.attempt_number), value=(s1.attempt_number >= 2))
+
+        r1 = AsyncRetrying(sleep=None, wait=wait_none(), stop=f1)
+
+        async def f2():
+            raise ValueError("x")
+
+        with self.assertRaises(RetryError):
+            await r1(f2)
+        self.assertEqual(v1, [("s", 1), ("s", 2)])
+
+    @asynctest
+    async def test_behavior_32(self):
+        def f1(_):
+            return a1([], "cb", value="done")
+
+        r1 = AsyncRetrying(
+            sleep=None,
+            wait=wait_none(),
+            stop=stop_after_attempt(2),
+            retry_error_callback=f1,
+        )
+
+        async def f2():
+            raise ValueError("x")
+
+        out = await r1(f2)
+        self.assertEqual(out, "done")
+
+    @asynctest
+    async def test_behavior_33(self):
+        c1 = C1()
+        tenacity.nap.sleep = c1
+        c2 = C2()
+        r1 = AsyncRetrying(sleep=c2, wait=wait_fixed(0.1), stop=stop_after_attempt(3))
+        n1 = {"v": 0}
+
+        async def f1():
+            n1["v"] += 1
+            if n1["v"] < 3:
+                raise ValueError("x")
+            return "ok"
+
+        out = await r1(f1)
+        self.assertEqual(out, "ok")
+        self.assertEqual(c1.v, [])
+        self.assertEqual(c2.v, [0.1, 0.1])
+
+    @asynctest
+    async def test_behavior_34(self):
+        v1 = []
+
+        def f1(s1):
+            return a1(v1, ("bs", s1.attempt_number), value=None)
+
+        r1 = AsyncRetrying(sleep=None, wait=wait_fixed(1), stop=stop_after_attempt(3), before_sleep=f1)
+
+        async def f2():
+            raise ValueError("x")
+
+        with self.assertRaises(RetryError):
+            await r1(f2)
+        self.assertEqual(v1, [])
+        self.assertAlmostEqual(r1.statistics["idle_for"], 2.0, places=5)
+
+    @asynctest
+    async def test_behavior_35(self):
+        calls = []
+
+        def f1(s1):
+            calls.append(("before", s1.attempt_number))
+            return a1([], ("x", s1.attempt_number), value=None)
+
+        def f2(s1):
+            calls.append(("after", s1.attempt_number))
+            return a1([], ("y", s1.attempt_number), value=None)
+
+        r1 = AsyncRetrying(sleep=None, wait=wait_none(), stop=stop_after_attempt(2), before=f1, after=f2)
+
+        async def f3():
+            raise ValueError("x")
+
+        with self.assertRaises(RetryError):
+            await r1(f3)
+        self.assertEqual(calls, [("before", 1), ("after", 1), ("before", 2), ("after", 2)])
+
+
+@unittest.skipUnless(HAS_TORNADO, "tornado not installed")
+class TestF(unittest.TestCase):
+    def setUp(self):
+        self._old_sleep = tenacity.nap.sleep
+
+    def tearDown(self):
+        tenacity.nap.sleep = self._old_sleep
+
+    def test_behavior_36(self):
+        v1 = []
+
+        def f1(s1):
+            return t1(v1, ("b", s1.attempt_number), value=None)
+
+        r1 = TornadoRetrying(sleep=None, wait=wait_none(), stop=stop_after_attempt(2), before=f1)
+        n1 = {"v": 0}
+
+        @gen.coroutine
+        def f2():
+            n1["v"] += 1
+            if n1["v"] < 2:
+                raise ValueError("x")
+            raise gen.Return("ok")
+
+        out = IOLoop().run_sync(lambda: r1(f2))
+        self.assertEqual(out, "ok")
+        self.assertEqual(v1, [("b", 1), ("b", 2)])
+
+    def test_behavior_37(self):
+        v1 = []
+
+        def f1(s1):
+            return t1(v1, ("a", s1.attempt_number), value=None)
+
+        r1 = TornadoRetrying(sleep=None, wait=wait_none(), stop=stop_after_attempt(2), after=f1)
+
+        @gen.coroutine
+        def f2():
+            raise ValueError("x")
+
+        with self.assertRaises(RetryError):
+            IOLoop().run_sync(lambda: r1(f2))
+        self.assertEqual(v1, [("a", 1), ("a", 2)])
+
+    def test_behavior_38(self):
+        calls = []
+
+        def f1(s1):
+            calls.append(s1.attempt_number)
+            return t1([], ("w", s1.attempt_number), value=1.25)
+
+        r1 = TornadoRetrying(sleep=None, wait=f1, stop=stop_after_attempt(3))
+        n1 = {"v": 0}
+
+        @gen.coroutine
+        def f2():
+            n1["v"] += 1
+            if n1["v"] < 3:
+                raise ValueError("x")
+            raise gen.Return("ok")
+
+        out = IOLoop().run_sync(lambda: r1(f2))
+        self.assertEqual(out, "ok")
+        self.assertEqual(calls, [1, 2])
+        self.assertAlmostEqual(r1.statistics["idle_for"], 2.5, places=5)
+
+    def test_behavior_39(self):
+        v1 = []
+        c1 = C1()
+
+        def f1(s1):
+            return t1(v1, ("bs", s1.attempt_number), value=None)
+
+        r1 = TornadoRetrying(sleep=c1, wait=wait_fixed(0.5), stop=stop_after_attempt(3), before_sleep=f1)
+        n1 = {"v": 0}
+
+        @gen.coroutine
+        def f2():
+            n1["v"] += 1
+            if n1["v"] < 3:
+                raise ValueError("x")
+            raise gen.Return("ok")
+
+        out = IOLoop().run_sync(lambda: r1(f2))
+        self.assertEqual(out, "ok")
+        self.assertEqual(v1, [("bs", 1), ("bs", 2)])
+        self.assertEqual(c1.v, [0.5, 0.5])
+
+    def test_behavior_40(self):
+        v1 = []
+
+        def f1(s1):
+            return t1(v1, ("r", s1.attempt_number), value=False)
+
+        r1 = TornadoRetrying(sleep=None, wait=wait_none(), retry=f1, stop=stop_after_attempt(5))
+
+        @gen.coroutine
+        def f2():
+            raise ValueError("x")
+
+        with self.assertRaises(ValueError):
+            IOLoop().run_sync(lambda: r1(f2))
+        self.assertEqual(v1, [("r", 1)])
+
+    def test_behavior_46(self):
+        calls = []
+        n1 = {"v": 0}
+
+        @gen.coroutine
+        def wait_fn(retry_state):
+            calls.append(("w", retry_state.attempt_number))
+            raise gen.Return(t1([], ("inner", retry_state.attempt_number), value=1.0))
+
+        r1 = TornadoRetrying(sleep=None, wait=wait_fn, stop=stop_after_attempt(3))
+
+        @gen.coroutine
+        def f1():
+            n1["v"] += 1
+            if n1["v"] < 3:
+                raise ValueError("x")
+            raise gen.Return("ok")
+
+        out = IOLoop().run_sync(lambda: r1(f1))
+        self.assertEqual(out, "ok")
+        self.assertEqual(calls, [("w", 1), ("w", 2)])
+        self.assertAlmostEqual(r1.statistics["idle_for"], 2.0, places=5)
+
+
+class TestG(unittest.TestCase):
+    def setUp(self):
+        self._old_sleep = tenacity.nap.sleep
+
+    def tearDown(self):
+        tenacity.nap.sleep = self._old_sleep
+
+    def test_behavior_41(self):
+        seen_wait = []
+        seen_before_sleep = []
+        r1 = Retrying(
+            sleep=None,
+            wait=lambda s1: seen_wait.append(s1.attempt_number) or 1.5,
+            stop=stop_after_attempt(3),
+            before_sleep=lambda s1: seen_before_sleep.append(s1.attempt_number),
+        )
+        n1 = {"v": 0}
+
+        for attempt in r1:
+            with attempt:
+                n1["v"] += 1
+                if n1["v"] < 3:
+                    raise ValueError("x")
+
+        self.assertEqual(n1["v"], 3)
+        self.assertEqual(seen_wait, [1, 2])
+        self.assertEqual(seen_before_sleep, [])
+        self.assertAlmostEqual(r1.statistics["idle_for"], 3.0, places=5)
+
+    def test_behavior_42(self):
+        c1 = C1()
+        c2 = C1()
+        tenacity.nap.sleep = c1
+        r1 = Retrying(wait=wait_fixed(1), stop=stop_after_attempt(3))
+        tenacity.nap.sleep = c2
+        n1 = {"v": 0}
+
+        with self.assertRaises(RetryError):
+            for attempt in r1:
+                with attempt:
+                    n1["v"] += 1
+                    raise ValueError("x")
+
+        self.assertEqual(n1["v"], 3)
+        self.assertEqual(c1.v, [1.0, 1.0])
+        self.assertEqual(c2.v, [])
+
+
+class TestH(unittest.TestCase):
+    def setUp(self):
+        self._old_sleep = tenacity.nap.sleep
+
+    def tearDown(self):
+        tenacity.nap.sleep = self._old_sleep
+
+    @asynctest
+    async def test_behavior_43(self):
+        seen_wait = []
+        seen_before_sleep = []
+        r1 = AsyncRetrying(
+            sleep=None,
+            wait=lambda s1: seen_wait.append(s1.attempt_number) or a1([], ("w", s1.attempt_number), value=1.25),
+            stop=stop_after_attempt(3),
+            before_sleep=lambda s1: seen_before_sleep.append(s1.attempt_number) or a1([], ("b", s1.attempt_number), value=None),
+        )
+        n1 = {"v": 0}
+
+        async for attempt in r1:
+            with attempt:
+                n1["v"] += 1
+                if n1["v"] < 3:
+                    raise ValueError("x")
+
+        self.assertEqual(n1["v"], 3)
+        self.assertEqual(seen_wait, [1, 2])
+        self.assertEqual(seen_before_sleep, [])
+        self.assertAlmostEqual(r1.statistics["idle_for"], 2.5, places=5)
+
+    @asynctest
+    async def test_behavior_44(self):
+        seen = []
+        r1 = AsyncRetrying(
+            sleep=None,
+            wait=wait_none(),
+            retry=lambda s1: a1(seen, ("r", s1.attempt_number), value=True),
+            stop=lambda s1: a1(seen, ("s", s1.attempt_number), value=(s1.attempt_number >= 2)),
+        )
+
+        with self.assertRaises(RetryError):
+            async for attempt in r1:
+                with attempt:
+                    raise ValueError("x")
+
+        self.assertEqual(seen, [("r", 1), ("s", 1), ("r", 2), ("s", 2)])
+
+    @asynctest
+    async def test_behavior_45(self):
+        calls = []
+        n1 = {"v": 0}
+
+        async def wait_fn(retry_state):
+            calls.append(("w", retry_state.attempt_number))
+            return a1([], ("inner", retry_state.attempt_number), value=1.0)
+
+        r1 = AsyncRetrying(sleep=None, wait=wait_fn, stop=stop_after_attempt(3))
+
+        async def f1():
+            n1["v"] += 1
+            if n1["v"] < 3:
+                raise ValueError("x")
+            return "ok"
+
+        out = await r1(f1)
+        self.assertEqual(out, "ok")
+        self.assertEqual(calls, [("w", 1), ("w", 2)])
+        self.assertAlmostEqual(r1.statistics["idle_for"], 2.0, places=5)


### PR DESCRIPTION
## Summary
- bind default sync sleep at controller construction time
- allow sleep-less retries to keep wait accounting without calling before_sleep
- fully resolve nested awaitables in async and tornado retry callbacks

## Testing
- Not run locally in this environment because no usable Python interpreter was available from PowerShell.