### PR TITLE
Allow after hooks to override retry delay

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -114,6 +114,7 @@ class IterState:
     retry_run_result: bool = False
     delay_since_first_attempt: int = 0
     stop_run_result: bool = False
+    after_sleep_override: t.Optional[float] = None
     is_explicit_retry: bool = False
 
     def reset(self) -> None:
@@ -121,6 +122,7 @@ class IterState:
         self.retry_run_result = False
         self.delay_since_first_attempt = 0
         self.stop_run_result = False
+        self.after_sleep_override = None
         self.is_explicit_retry = False
 
 
@@ -364,6 +366,17 @@ class BaseRetrying(ABC):
 
         retry_state.upcoming_sleep = sleep
 
+    def _coerce_sleep_override(self, value: t.Any) -> t.Optional[float]:
+        if value is None:
+            return None
+
+        sleep = float(value)
+        return 0.0 if sleep < 0.0 else sleep
+
+    def _run_after(self, retry_state: "RetryCallState") -> None:
+        result = self.after(retry_state)
+        self.iter_state.after_sleep_override = self._coerce_sleep_override(result)
+
     def _run_stop(self, retry_state: "RetryCallState") -> None:
         self.statistics["delay_since_first_attempt"] = retry_state.seconds_since_start
         self.iter_state.stop_run_result = self.stop(retry_state)
@@ -398,7 +411,7 @@ class BaseRetrying(ABC):
             return
 
         if self.after is not None:
-            self._add_action_func(self.after)
+            self._add_action_func(self._run_after)
 
         self._add_action_func(self._run_wait)
         self._add_action_func(self._run_stop)
@@ -422,6 +435,10 @@ class BaseRetrying(ABC):
 
         def next_action(rs: "RetryCallState") -> None:
             sleep = rs.upcoming_sleep
+            if self.iter_state.after_sleep_override is not None:
+                sleep = self.iter_state.after_sleep_override
+                rs.upcoming_sleep = sleep
+
             rs.next_action = RetryAction(sleep)
             rs.idle_for += sleep
             self.statistics["idle_for"] += sleep

--- a/tenacity/asyncio/__init__.py
+++ b/tenacity/asyncio/__init__.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 import functools
+import inspect
 import sys
 import typing as t
 
@@ -44,6 +45,12 @@ if t.TYPE_CHECKING:
 
 WrappedFnReturnT = t.TypeVar("WrappedFnReturnT")
 WrappedFn = t.TypeVar("WrappedFn", bound=t.Callable[..., t.Awaitable[t.Any]])
+
+
+async def _resolve_awaitables(value: t.Any) -> t.Any:
+    while inspect.isawaitable(value):
+        value = await value
+    return value
 
 
 def _portable_async_sleep(seconds: float) -> t.Awaitable[None]:
@@ -129,6 +136,11 @@ class AsyncRetrying(BaseRetrying):
         self.iter_state.retry_run_result = await _utils.wrap_to_async_func(self.retry)(
             retry_state
         )
+
+    async def _run_after(self, retry_state: "RetryCallState") -> None:  # type: ignore[override]
+        result = await _utils.wrap_to_async_func(self.after)(retry_state)
+        result = await _resolve_awaitables(result)
+        self.iter_state.after_sleep_override = self._coerce_sleep_override(result)
 
     async def _run_wait(self, retry_state: "RetryCallState") -> None:  # type: ignore[override]
         if self.wait:

--- a/tenacity/tornadoweb.py
+++ b/tenacity/tornadoweb.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import sys
 import typing
 
@@ -37,6 +38,37 @@ class TornadoRetrying(BaseRetrying):
         super().__init__(**kwargs)
         self.sleep = sleep
 
+    @staticmethod
+    def _is_awaitable(value: typing.Any) -> bool:
+        return gen.is_future(value) or inspect.isawaitable(value)
+
+    @gen.coroutine  # type: ignore[untyped-decorator]
+    def _resolve_awaitable(
+        self, value: typing.Any
+    ) -> "typing.Generator[typing.Any, typing.Any, typing.Any]":
+        while self._is_awaitable(value):
+            value = yield value
+        raise gen.Return(value)
+
+    @gen.coroutine  # type: ignore[override, untyped-decorator]
+    def _run_after(
+        self, retry_state: "RetryCallState"
+    ) -> "typing.Generator[typing.Any, typing.Any, None]":
+        result = self.after(retry_state)
+        result = yield self._resolve_awaitable(result)
+        self.iter_state.after_sleep_override = self._coerce_sleep_override(result)
+
+    @gen.coroutine  # type: ignore[override, untyped-decorator]
+    def iter(
+        self, retry_state: "RetryCallState"
+    ) -> "typing.Generator[typing.Any, typing.Any, typing.Union[DoAttempt, DoSleep, typing.Any]]":
+        self._begin_iter(retry_state)
+        result = None
+        for action in self.iter_state.actions:
+            result = action(retry_state)
+            result = yield self._resolve_awaitable(result)
+        raise gen.Return(result)
+
     @gen.coroutine  # type: ignore[untyped-decorator]
     def __call__(
         self,
@@ -48,7 +80,7 @@ class TornadoRetrying(BaseRetrying):
 
         retry_state = RetryCallState(retry_object=self, fn=fn, args=args, kwargs=kwargs)
         while True:
-            do = self.iter(retry_state=retry_state)
+            do = yield self.iter(retry_state=retry_state)
             if isinstance(do, DoAttempt):
                 try:
                     result = yield fn(*args, **kwargs)
@@ -58,6 +90,7 @@ class TornadoRetrying(BaseRetrying):
                     retry_state.set_result(result)
             elif isinstance(do, DoSleep):
                 retry_state.prepare_for_next_attempt()
-                yield self.sleep(do)
+                sleep_result = self.sleep(do)
+                yield self._resolve_awaitable(sleep_result)
             else:
                 raise gen.Return(do)

--- a/test_3.sh
+++ b/test_3.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -e
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 {base|new}"
+    exit 1
+fi
+
+PYTHON_BIN=
+for candidate in py.exe py python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+        if "$candidate" -c "import pytest, tenacity" >/dev/null 2>&1; then
+            PYTHON_BIN="$candidate"
+            break
+        fi
+    fi
+done
+
+if [ -z "$PYTHON_BIN" ]; then
+    echo "No python interpreter found with pytest and tenacity installed"
+    exit 1
+fi
+
+case "$1" in
+    base)
+        "$PYTHON_BIN" -m pytest -v tests/test_tenacity.py::TestBeforeAfterAttempts::test_before_attempts
+        ;;
+    new)
+        "$PYTHON_BIN" -m pytest -v tests/test_after_sleep_override.py
+        ;;
+    *)
+        echo "Usage: $0 {base|new}"
+        exit 1
+        ;;
+esac

--- a/tests/test_after_sleep_override.py
+++ b/tests/test_after_sleep_override.py
@@ -1,0 +1,976 @@
+"""Tests for after return value overriding sleep duration."""
+import asyncio
+import unittest
+
+import tenacity
+from tenacity import (
+    RetryCallState,
+    Retrying,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_fixed,
+    wait_none,
+)
+
+try:
+    from tenacity import tornadoweb
+    from tornado import concurrent
+    from tornado import gen
+    from tornado import ioloop
+except ImportError:
+    HAS_TORNADO = False
+else:
+    HAS_TORNADO = True
+
+
+class TestAfterOverrideSyncBasic(unittest.TestCase):
+    """after return value overrides sleep duration in sync."""
+
+    def test_none_return_keeps_original_sleep(self):
+        sleeps = []
+
+        def my_after(retry_state):
+            return None  # No override
+
+        def record_sleep(seconds):
+            sleeps.append(seconds)
+
+        call_count = 0
+
+        @retry(
+            stop=stop_after_attempt(3),
+            wait=wait_fixed(5),
+            after=my_after,
+            sleep=record_sleep,
+            reraise=True,
+        )
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ValueError("retry")
+            return "ok"
+
+        fn()
+        # Sleep should be 5.0 (original), not overridden
+        self.assertEqual(sleeps, [5.0, 5.0])
+
+    def test_float_return_overrides_sleep(self):
+        sleeps = []
+
+        def my_after(retry_state):
+            return 1.0  # Override to 1 second
+
+        def record_sleep(seconds):
+            sleeps.append(seconds)
+
+        call_count = 0
+
+        @retry(
+            stop=stop_after_attempt(3),
+            wait=wait_fixed(5),
+            after=my_after,
+            sleep=record_sleep,
+            reraise=True,
+        )
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ValueError("retry")
+            return "ok"
+
+        fn()
+        # Sleep should be overridden to 1.0
+        self.assertEqual(sleeps, [1.0, 1.0])
+
+    def test_zero_return_overrides_to_zero(self):
+        sleeps = []
+
+        def my_after(retry_state):
+            return 0.0
+
+        def record_sleep(seconds):
+            sleeps.append(seconds)
+
+        call_count = 0
+
+        @retry(
+            stop=stop_after_attempt(2),
+            wait=wait_fixed(10),
+            after=my_after,
+            sleep=record_sleep,
+            reraise=True,
+        )
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("retry")
+            return "ok"
+
+        fn()
+        self.assertEqual(sleeps, [0.0])
+
+    def test_negative_return_clamped_to_zero(self):
+        sleeps = []
+
+        def my_after(retry_state):
+            return -5.0  # Negative should be clamped to 0
+
+        def record_sleep(seconds):
+            sleeps.append(seconds)
+
+        call_count = 0
+
+        @retry(
+            stop=stop_after_attempt(2),
+            wait=wait_fixed(10),
+            after=my_after,
+            sleep=record_sleep,
+            reraise=True,
+        )
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("retry")
+            return "ok"
+
+        fn()
+        self.assertEqual(sleeps, [0.0])
+
+    def test_int_return_overrides_sleep(self):
+        sleeps = []
+
+        def my_after(retry_state):
+            return 3
+
+        def record_sleep(seconds):
+            sleeps.append(seconds)
+
+        call_count = 0
+
+        @retry(
+            stop=stop_after_attempt(2),
+            wait=wait_fixed(10),
+            after=my_after,
+            sleep=record_sleep,
+            reraise=True,
+        )
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("retry")
+            return "ok"
+
+        fn()
+        self.assertEqual(sleeps, [3.0])
+        self.assertIsInstance(sleeps[0], float)
+
+
+class TestAfterOverrideIdleFor(unittest.TestCase):
+    """idle_for statistics tracks the overridden delay value."""
+
+    def test_idle_for_tracks_overridden_value(self):
+        def my_after(retry_state):
+            return 2.0  # Override from 10 to 2
+
+        call_count = 0
+
+        @retry(
+            stop=stop_after_attempt(4),
+            wait=wait_fixed(10),
+            after=my_after,
+            sleep=lambda x: None,  # no-op sleep
+            reraise=True,
+        )
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 4:
+                raise ValueError("retry")
+            return "ok"
+
+        result = fn()
+        self.assertEqual(result, "ok")
+        # idle_for should track overridden sleep (2.0 * 3 retries = 6.0)
+        self.assertEqual(fn.statistics["idle_for"], 6.0)
+
+    def test_idle_for_with_no_override(self):
+        def my_after(retry_state):
+            return None  # No override
+
+        call_count = 0
+
+        @retry(
+            stop=stop_after_attempt(3),
+            wait=wait_fixed(5),
+            after=my_after,
+            sleep=lambda x: None,
+            reraise=True,
+        )
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ValueError("retry")
+            return "ok"
+
+        fn()
+        # idle_for should track original (5.0 * 2 = 10.0)
+        self.assertEqual(fn.statistics["idle_for"], 10.0)
+
+    def test_idle_for_mixed_overrides(self):
+        """Some retries override, some don't."""
+        call_count = 0
+
+        def my_after(retry_state):
+            # Override only on first retry
+            if retry_state.attempt_number == 1:
+                return 1.0
+            return None
+
+        @retry(
+            stop=stop_after_attempt(4),
+            wait=wait_fixed(5),
+            after=my_after,
+            sleep=lambda x: None,
+            reraise=True,
+        )
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 4:
+                raise ValueError("retry")
+            return "ok"
+
+        fn()
+        # Attempt 1 fails -> after returns 1.0 (override)
+        # Attempt 2 fails -> after returns None (keep 5.0)
+        # Attempt 3 fails -> after returns None (keep 5.0)
+        # Attempt 4 succeeds
+        self.assertEqual(fn.statistics["idle_for"], 1.0 + 5.0 + 5.0)
+
+
+class TestAfterOverrideSleepAction(unittest.TestCase):
+    """Sleep action receives the overridden delay value."""
+
+    def test_sleep_receives_overridden_value(self):
+        captured = []
+
+        def my_after(retry_state):
+            return 2.0
+
+        call_count = 0
+
+        @retry(
+            stop=stop_after_attempt(2),
+            wait=wait_fixed(10),
+            after=my_after,
+            sleep=lambda x: captured.append(x),
+            reraise=True,
+        )
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("retry")
+            return "ok"
+
+        fn()
+        self.assertEqual(captured, [2.0])
+
+
+class TestAfterOverrideNoAfter(unittest.TestCase):
+    """When after is None, behavior is unchanged."""
+
+    def test_no_after_original_sleep(self):
+        sleeps = []
+
+        call_count = 0
+
+        @retry(
+            stop=stop_after_attempt(2),
+            wait=wait_fixed(5),
+            after=None,
+            sleep=lambda x: sleeps.append(x),
+            reraise=True,
+        )
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("retry")
+            return "ok"
+
+        fn()
+        self.assertEqual(sleeps, [5.0])
+
+
+class TestAfterOverrideBackwardCompat(unittest.TestCase):
+    """Existing after callbacks that return None still work."""
+
+    def test_existing_callback_returning_none_implicitly(self):
+        sleeps = []
+        callback_called = []
+
+        def my_after(retry_state):
+            callback_called.append(True)
+            # Implicit None return
+
+        call_count = 0
+
+        @retry(
+            stop=stop_after_attempt(2),
+            wait=wait_fixed(5),
+            after=my_after,
+            sleep=lambda x: sleeps.append(x),
+            reraise=True,
+        )
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("retry")
+            return "ok"
+
+        fn()
+        self.assertTrue(callback_called)
+        self.assertEqual(sleeps, [5.0])
+
+
+def _make_async_sleep_recorder(sleeps_list):
+    """Create an async sleep function that records durations."""
+    async def async_sleep(seconds):
+        sleeps_list.append(seconds)
+    return async_sleep
+
+
+class TestAfterOverrideAsync(unittest.TestCase):
+    """Override works with async retrying."""
+
+    def test_async_sync_callback_override(self):
+        sleeps = []
+
+        def my_after(retry_state):
+            return 1.0
+
+        call_count = 0
+
+        @retry(
+            stop=stop_after_attempt(3),
+            wait=wait_fixed(10),
+            after=my_after,
+            sleep=_make_async_sleep_recorder(sleeps),
+            reraise=True,
+        )
+        async def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ValueError("retry")
+            return "ok"
+
+        asyncio.run(fn())
+        self.assertEqual(sleeps, [1.0, 1.0])
+
+    def test_async_callback_override(self):
+        sleeps = []
+
+        async def my_after(retry_state):
+            return 2.0
+
+        call_count = 0
+
+        @retry(
+            stop=stop_after_attempt(2),
+            wait=wait_fixed(10),
+            after=my_after,
+            sleep=_make_async_sleep_recorder(sleeps),
+            reraise=True,
+        )
+        async def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("retry")
+            return "ok"
+
+        asyncio.run(fn())
+        self.assertEqual(sleeps, [2.0])
+
+    def test_async_callback_none_no_override(self):
+        sleeps = []
+
+        async def my_after(retry_state):
+            return None
+
+        call_count = 0
+
+        @retry(
+            stop=stop_after_attempt(2),
+            wait=wait_fixed(5),
+            after=my_after,
+            sleep=_make_async_sleep_recorder(sleeps),
+            reraise=True,
+        )
+        async def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("retry")
+            return "ok"
+
+        asyncio.run(fn())
+        self.assertEqual(sleeps, [5.0])
+
+    def test_async_negative_override_clamped_to_zero(self):
+        sleeps = []
+
+        async def my_after(retry_state):
+            return -7.0
+
+        call_count = 0
+
+        @retry(
+            stop=stop_after_attempt(2),
+            wait=wait_fixed(5),
+            after=my_after,
+            sleep=_make_async_sleep_recorder(sleeps),
+            reraise=True,
+        )
+        async def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("retry")
+            return "ok"
+
+        asyncio.run(fn())
+        self.assertEqual(sleeps, [0.0])
+
+    def test_async_sync_callback_returning_awaitable_override(self):
+        sleeps = []
+
+        async def override_value():
+            return 1.25
+
+        def my_after(retry_state):
+            return override_value()
+
+        call_count = 0
+
+        @retry(
+            stop=stop_after_attempt(2),
+            wait=wait_fixed(10),
+            after=my_after,
+            sleep=_make_async_sleep_recorder(sleeps),
+            reraise=True,
+        )
+        async def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("retry")
+            return "ok"
+
+        asyncio.run(fn())
+        self.assertEqual(sleeps, [1.25])
+
+    def test_async_callback_returning_nested_awaitable_override(self):
+        sleeps = []
+
+        async def nested_override_value():
+            async def final_value():
+                return 0.75
+
+            return final_value()
+
+        async def my_after(retry_state):
+            return nested_override_value()
+
+        call_count = 0
+
+        @retry(
+            stop=stop_after_attempt(2),
+            wait=wait_fixed(10),
+            after=my_after,
+            sleep=_make_async_sleep_recorder(sleeps),
+            reraise=True,
+        )
+        async def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("retry")
+            return "ok"
+
+        asyncio.run(fn())
+        self.assertEqual(sleeps, [0.75])
+
+    def test_async_nested_awaitable_resolving_none_keeps_original_sleep(self):
+        sleeps = []
+
+        async def nested_none():
+            async def final_none():
+                return None
+
+            return final_none()
+
+        def my_after(retry_state):
+            return nested_none()
+
+        call_count = 0
+
+        @retry(
+            stop=stop_after_attempt(2),
+            wait=wait_fixed(4),
+            after=my_after,
+            sleep=_make_async_sleep_recorder(sleeps),
+            reraise=True,
+        )
+        async def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("retry")
+            return "ok"
+
+        asyncio.run(fn())
+        self.assertEqual(sleeps, [4.0])
+
+    def test_async_idle_for_tracks_override(self):
+        async def my_after(retry_state):
+            return 1.0
+
+        call_count = 0
+
+        @retry(
+            stop=stop_after_attempt(3),
+            wait=wait_fixed(10),
+            after=my_after,
+            sleep=_make_async_sleep_recorder([]),
+            reraise=True,
+        )
+        async def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ValueError("retry")
+            return "ok"
+
+        asyncio.run(fn())
+        self.assertEqual(fn.statistics["idle_for"], 2.0)  # 1.0 * 2 retries
+
+
+@unittest.skipUnless(HAS_TORNADO, "tornado is not installed")
+class TestAfterOverrideTornado(unittest.TestCase):
+    """Override works with tornado retrying, including awaitable returns."""
+
+    def _run_sync(self, callback):
+        loop = ioloop.IOLoop()
+        try:
+            return loop.run_sync(callback)
+        finally:
+            loop.close()
+
+    def test_tornado_sync_callback_returning_future_override(self):
+        sleeps = []
+
+        def my_after(retry_state):
+            future = concurrent.Future()
+            future.set_result(1.5)
+            return future
+
+        def record_sleep(seconds):
+            sleeps.append(seconds)
+            future = concurrent.Future()
+            future.set_result(None)
+            return future
+
+        retrying = tornadoweb.TornadoRetrying(
+            stop=stop_after_attempt(2),
+            wait=wait_fixed(10),
+            retry=retry_if_exception_type(ValueError),
+            after=my_after,
+            sleep=record_sleep,
+            reraise=True,
+        )
+
+        call_count = 0
+
+        @gen.coroutine
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("retry")
+            raise gen.Return("ok")
+
+        result = self._run_sync(lambda: retrying(fn))
+        self.assertEqual(result, "ok")
+        self.assertEqual(sleeps, [1.5])
+
+    def test_tornado_negative_override_clamped_to_zero(self):
+        sleeps = []
+
+        def my_after(retry_state):
+            future = concurrent.Future()
+            future.set_result(-9.0)
+            return future
+
+        def record_sleep(seconds):
+            sleeps.append(seconds)
+            future = concurrent.Future()
+            future.set_result(None)
+            return future
+
+        retrying = tornadoweb.TornadoRetrying(
+            stop=stop_after_attempt(2),
+            wait=wait_fixed(10),
+            retry=retry_if_exception_type(ValueError),
+            after=my_after,
+            sleep=record_sleep,
+            reraise=True,
+        )
+
+        call_count = 0
+
+        @gen.coroutine
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("retry")
+            raise gen.Return("ok")
+
+        result = self._run_sync(lambda: retrying(fn))
+        self.assertEqual(result, "ok")
+        self.assertEqual(sleeps, [0.0])
+
+    def test_tornado_callback_returning_nested_awaitable_override(self):
+        sleeps = []
+
+        @gen.coroutine
+        def nested_override():
+            future = concurrent.Future()
+            future.set_result(0.25)
+            raise gen.Return(future)
+
+        @gen.coroutine
+        def my_after(retry_state):
+            raise gen.Return(nested_override())
+
+        def record_sleep(seconds):
+            sleeps.append(seconds)
+            future = concurrent.Future()
+            future.set_result(None)
+            return future
+
+        retrying = tornadoweb.TornadoRetrying(
+            stop=stop_after_attempt(2),
+            wait=wait_fixed(10),
+            retry=retry_if_exception_type(ValueError),
+            after=my_after,
+            sleep=record_sleep,
+            reraise=True,
+        )
+
+        call_count = 0
+
+        @gen.coroutine
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("retry")
+            raise gen.Return("ok")
+
+        result = self._run_sync(lambda: retrying(fn))
+        self.assertEqual(result, "ok")
+        self.assertEqual(sleeps, [0.25])
+
+    def test_tornado_nested_awaitable_none_keeps_original_sleep(self):
+        sleeps = []
+
+        @gen.coroutine
+        def nested_none():
+            future = concurrent.Future()
+            future.set_result(None)
+            raise gen.Return(future)
+
+        def my_after(retry_state):
+            return nested_none()
+
+        def record_sleep(seconds):
+            sleeps.append(seconds)
+            future = concurrent.Future()
+            future.set_result(None)
+            return future
+
+        retrying = tornadoweb.TornadoRetrying(
+            stop=stop_after_attempt(2),
+            wait=wait_fixed(3),
+            retry=retry_if_exception_type(ValueError),
+            after=my_after,
+            sleep=record_sleep,
+            reraise=True,
+        )
+
+        call_count = 0
+
+        @gen.coroutine
+        def fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("retry")
+            raise gen.Return("ok")
+
+        result = self._run_sync(lambda: retrying(fn))
+        self.assertEqual(result, "ok")
+        self.assertEqual(sleeps, [3.0])
+
+
+class TestAfterOverrideSyncEdgeCases(unittest.TestCase):
+    def test_false_return_overrides_to_zero(self):
+        sleeps = []
+
+        @retry(
+            stop=stop_after_attempt(2),
+            wait=wait_fixed(9),
+            after=lambda _: False,
+            sleep=lambda x: sleeps.append(x),
+            reraise=True,
+        )
+        def fn():
+            raise ValueError("retry")
+
+        with self.assertRaises(ValueError):
+            fn()
+        self.assertEqual(sleeps, [0.0])
+
+    def test_after_receives_attempt_numbers_for_retries(self):
+        seen = []
+        calls = {"n": 0}
+
+        @retry(stop=stop_after_attempt(4), wait=wait_fixed(1), after=lambda rs: seen.append(rs.attempt_number), sleep=lambda _: None, reraise=True)
+        def fn():
+            calls["n"] += 1
+            if calls["n"] < 4:
+                raise ValueError("retry")
+            return "ok"
+
+        self.assertEqual(fn(), "ok")
+        self.assertEqual(seen, [1, 2, 3])
+
+    def test_wait_none_with_override_uses_after_value(self):
+        sleeps = []
+        calls = {"n": 0}
+
+        @retry(stop=stop_after_attempt(3), wait=wait_none(), after=lambda _: 1.75, sleep=lambda x: sleeps.append(x), reraise=True)
+        def fn():
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise ValueError("retry")
+            return "ok"
+
+        self.assertEqual(fn(), "ok")
+        self.assertEqual(sleeps, [1.75, 1.75])
+
+
+class TestAfterOverrideAsyncEdgeCases(unittest.TestCase):
+    def test_async_false_return_overrides_to_zero(self):
+        sleeps = []
+        calls = {"n": 0}
+
+        @retry(stop=stop_after_attempt(2), wait=wait_fixed(6), after=lambda _: False, sleep=_make_async_sleep_recorder(sleeps), reraise=True)
+        async def fn():
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise ValueError("retry")
+            return "ok"
+
+        self.assertEqual(asyncio.run(fn()), "ok")
+        self.assertEqual(sleeps, [0.0])
+
+    def test_async_after_attempt_numbers(self):
+        seen = []
+        calls = {"n": 0}
+
+        @retry(stop=stop_after_attempt(3), wait=wait_fixed(1), after=lambda rs: seen.append(rs.attempt_number), sleep=_make_async_sleep_recorder([]), reraise=True)
+        async def fn():
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise ValueError("retry")
+            return "ok"
+
+        self.assertEqual(asyncio.run(fn()), "ok")
+        self.assertEqual(seen, [1, 2])
+
+    def test_async_double_nested_awaitable_override(self):
+        sleeps = []
+        calls = {"n": 0}
+
+        async def lvl3():
+            return 0.5
+
+        async def lvl2():
+            return lvl3()
+
+        async def lvl1(_):
+            return lvl2()
+
+        @retry(stop=stop_after_attempt(2), wait=wait_fixed(9), after=lvl1, sleep=_make_async_sleep_recorder(sleeps), reraise=True)
+        async def fn():
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise ValueError("retry")
+            return "ok"
+
+        self.assertEqual(asyncio.run(fn()), "ok")
+        self.assertEqual(sleeps, [0.5])
+
+
+@unittest.skipUnless(HAS_TORNADO, "tornado is not installed")
+class TestAfterOverrideTornadoEdgeCases(unittest.TestCase):
+    def _run_sync(self, callback):
+        loop = ioloop.IOLoop()
+        try:
+            return loop.run_sync(callback)
+        finally:
+            loop.close()
+
+    def test_tornado_none_keeps_original_sleep(self):
+        sleeps = []
+        calls = {"n": 0}
+
+        def after_cb(_):
+            future = concurrent.Future()
+            future.set_result(None)
+            return future
+
+        def record_sleep(seconds):
+            sleeps.append(seconds)
+            future = concurrent.Future()
+            future.set_result(None)
+            return future
+
+        retrying = tornadoweb.TornadoRetrying(stop=stop_after_attempt(2), wait=wait_fixed(4), retry=retry_if_exception_type(ValueError), after=after_cb, sleep=record_sleep, reraise=True)
+
+        @gen.coroutine
+        def fn():
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise ValueError("retry")
+            raise gen.Return("ok")
+
+        self.assertEqual(self._run_sync(lambda: retrying(fn)), "ok")
+        self.assertEqual(sleeps, [4.0])
+
+    def test_tornado_false_overrides_to_zero(self):
+        sleeps = []
+        calls = {"n": 0}
+
+        def after_cb(_):
+            future = concurrent.Future()
+            future.set_result(False)
+            return future
+
+        def record_sleep(seconds):
+            sleeps.append(seconds)
+            future = concurrent.Future()
+            future.set_result(None)
+            return future
+
+        retrying = tornadoweb.TornadoRetrying(stop=stop_after_attempt(2), wait=wait_fixed(4), retry=retry_if_exception_type(ValueError), after=after_cb, sleep=record_sleep, reraise=True)
+
+        @gen.coroutine
+        def fn():
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise ValueError("retry")
+            raise gen.Return("ok")
+
+        self.assertEqual(self._run_sync(lambda: retrying(fn)), "ok")
+        self.assertEqual(sleeps, [0.0])
+
+    def test_tornado_idle_for_tracks_override(self):
+        calls = {"n": 0}
+
+        def after_cb(_):
+            future = concurrent.Future()
+            future.set_result(1.25)
+            return future
+
+        def record_sleep(_):
+            future = concurrent.Future()
+            future.set_result(None)
+            return future
+
+        retrying = tornadoweb.TornadoRetrying(stop=stop_after_attempt(3), wait=wait_fixed(6), retry=retry_if_exception_type(ValueError), after=after_cb, sleep=record_sleep, reraise=True)
+
+        @gen.coroutine
+        def fn():
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise ValueError("retry")
+            raise gen.Return("ok")
+
+        self.assertEqual(self._run_sync(lambda: retrying(fn)), "ok")
+        self.assertEqual(retrying.statistics["idle_for"], 2.5)
+
+
+class TestAfterOverrideManualIteration(unittest.TestCase):
+    """Override works with manual sync iteration."""
+
+    def test_manual_iteration_override(self):
+        sleeps = []
+
+        def my_after(retry_state):
+            return 0.5
+
+        r = Retrying(
+            stop=stop_after_attempt(3),
+            wait=wait_fixed(10),
+            after=my_after,
+            sleep=lambda x: sleeps.append(x),
+        )
+
+        for attempt in r:
+            with attempt:
+                if r.statistics.get("attempt_number", 1) < 3:
+                    raise ValueError("retry")
+
+        self.assertEqual(sleeps, [0.5, 0.5])
+
+    def test_manual_iteration_none_keeps_original(self):
+        sleeps = []
+
+        r = Retrying(stop=stop_after_attempt(3), wait=wait_fixed(2), after=lambda _: None, sleep=lambda x: sleeps.append(x))
+
+        for attempt in r:
+            with attempt:
+                if r.statistics.get("attempt_number", 1) < 3:
+                    raise ValueError("retry")
+
+        self.assertEqual(sleeps, [2.0, 2.0])
+
+    def test_manual_iteration_negative_clamps(self):
+        sleeps = []
+
+        r = Retrying(stop=stop_after_attempt(2), wait=wait_fixed(3), after=lambda _: -10, sleep=lambda x: sleeps.append(x))
+
+        for attempt in r:
+            with attempt:
+                if r.statistics.get("attempt_number", 1) < 2:
+                    raise ValueError("retry")
+
+        self.assertEqual(sleeps, [0.0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- let after callbacks replace the next retry delay with a non-None return value
- normalize override values to float seconds and clamp negatives to zero
- resolve async override values before applying them in async-capable retry controllers

## Testing
- Not run locally in this environment because no usable Python interpreter was available from PowerShell.