### PR TITLE
Preserve typing for retry-wrapped callables

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test_6.sh text eol=lf

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifier =
 
 [options]
 install_requires =
+    typing_extensions>=4.0; python_version < "3.10"
 python_requires = >=3.9
 packages = find:
 

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -27,6 +27,13 @@ from concurrent import futures
 
 from . import _utils
 
+if sys.version_info >= (3, 11):
+    from typing import ParamSpec
+elif sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
+
 # Import all built-in retry strategies for easier usage.
 from .retry import retry_base  # noqa
 from .retry import retry_all  # noqa
@@ -89,8 +96,6 @@ except ImportError:
 if t.TYPE_CHECKING:
     import types
 
-    from typing_extensions import Self
-
     from . import asyncio as tasyncio
     from .retry import RetryBaseT
     from .stop import StopBaseT
@@ -99,6 +104,40 @@ if t.TYPE_CHECKING:
 
 WrappedFnReturnT = t.TypeVar("WrappedFnReturnT")
 WrappedFn = t.TypeVar("WrappedFn", bound=t.Callable[..., t.Any])
+WrappedFnParams = ParamSpec("WrappedFnParams")
+WrappedRetryingT = t.TypeVar("WrappedRetryingT", bound="BaseRetrying")
+BaseRetryingType = t.TypeVar("BaseRetryingType", bound="BaseRetrying")
+
+
+class WrappedFnWithRetry(
+    t.Protocol[WrappedFnParams, WrappedFnReturnT, WrappedRetryingT]
+):
+    retry: WrappedRetryingT
+    retry_with: t.Callable[
+        ..., "WrappedFnWithRetry[WrappedFnParams, WrappedFnReturnT, WrappedRetryingT]"
+    ]
+    statistics: t.Dict[str, t.Any]
+
+    def __call__(
+        self, *args: WrappedFnParams.args, **kwargs: WrappedFnParams.kwargs
+    ) -> WrappedFnReturnT: ...
+
+
+class RetryDecorator(t.Protocol):
+    @t.overload
+    def __call__(
+        self,
+        fn: t.Callable[WrappedFnParams, t.Coroutine[t.Any, t.Any, WrappedFnReturnT]],
+    ) -> WrappedFnWithRetry[
+        WrappedFnParams,
+        t.Coroutine[t.Any, t.Any, WrappedFnReturnT],
+        "tasyncio.AsyncRetrying",
+    ]: ...
+
+    @t.overload
+    def __call__(
+        self, fn: t.Callable[WrappedFnParams, WrappedFnReturnT]
+    ) -> WrappedFnWithRetry[WrappedFnParams, WrappedFnReturnT, "Retrying"]: ...
 
 
 dataclass_kwargs = {}
@@ -318,7 +357,10 @@ class BaseRetrying(ABC):
             self._local.iter_state = IterState()
         return self._local.iter_state  # type: ignore[no-any-return]
 
-    def wraps(self, f: WrappedFn) -> WrappedFn:
+    def wraps(
+        self: BaseRetryingType,
+        f: t.Callable[WrappedFnParams, WrappedFnReturnT],
+    ) -> WrappedFnWithRetry[WrappedFnParams, WrappedFnReturnT, BaseRetryingType]:
         """Wrap a function for retrying.
 
         :param f: A function to wraps for retrying.
@@ -327,22 +369,34 @@ class BaseRetrying(ABC):
         @functools.wraps(
             f, functools.WRAPPER_ASSIGNMENTS + ("__defaults__", "__kwdefaults__")
         )
-        def wrapped_f(*args: t.Any, **kw: t.Any) -> t.Any:
+        def wrapped_f(
+            *args: WrappedFnParams.args, **kw: WrappedFnParams.kwargs
+        ) -> WrappedFnReturnT:
             # Always create a copy to prevent overwriting the local contexts when
             # calling the same wrapped functions multiple times in the same stack
             copy = self.copy()
-            wrapped_f.statistics = copy.statistics  # type: ignore[attr-defined]
+            wrapped.statistics = copy.statistics
             return copy(f, *args, **kw)
 
-        def retry_with(*args: t.Any, **kwargs: t.Any) -> WrappedFn:
+        def retry_with(
+            *args: t.Any, **kwargs: t.Any
+        ) -> WrappedFnWithRetry[
+            WrappedFnParams, WrappedFnReturnT, BaseRetryingType
+        ]:
             return self.copy(*args, **kwargs).wraps(f)
 
+        wrapped = t.cast(
+            WrappedFnWithRetry[
+                WrappedFnParams, WrappedFnReturnT, BaseRetryingType
+            ],
+            wrapped_f,
+        )
         # Preserve attributes
-        wrapped_f.retry = self  # type: ignore[attr-defined]
-        wrapped_f.retry_with = retry_with  # type: ignore[attr-defined]
-        wrapped_f.statistics = {}  # type: ignore[attr-defined]
+        wrapped.retry = self
+        wrapped.retry_with = retry_with
+        wrapped.statistics = {}
 
-        return wrapped_f  # type: ignore[return-value]
+        return wrapped
 
     def begin(self) -> None:
         self.statistics.clear()
@@ -595,7 +649,21 @@ class RetryCallState:
 
 
 @t.overload
-def retry(func: WrappedFn) -> WrappedFn: ...
+def retry(
+    func: t.Callable[
+        WrappedFnParams, t.Coroutine[t.Any, t.Any, WrappedFnReturnT]
+    ],
+) -> WrappedFnWithRetry[
+    WrappedFnParams,
+    t.Coroutine[t.Any, t.Any, WrappedFnReturnT],
+    "tasyncio.AsyncRetrying",
+]: ...
+
+
+@t.overload
+def retry(
+    func: t.Callable[WrappedFnParams, WrappedFnReturnT],
+) -> WrappedFnWithRetry[WrappedFnParams, WrappedFnReturnT, Retrying]: ...
 
 
 @t.overload
@@ -618,7 +686,7 @@ def retry(
     retry_error_callback: t.Optional[
         t.Callable[["RetryCallState"], t.Union[t.Any, t.Awaitable[t.Any]]]
     ] = None,
-) -> t.Callable[[WrappedFn], WrappedFn]: ...
+) -> RetryDecorator: ...
 
 
 def retry(*dargs: t.Any, **dkw: t.Any) -> t.Any:
@@ -632,7 +700,9 @@ def retry(*dargs: t.Any, **dkw: t.Any) -> t.Any:
         return retry()(dargs[0])
     else:
 
-        def wrap(f: WrappedFn) -> WrappedFn:
+        def wrap(
+            f: t.Callable[WrappedFnParams, WrappedFnReturnT]
+        ) -> WrappedFnWithRetry[WrappedFnParams, WrappedFnReturnT, BaseRetrying]:
             if isinstance(f, retry_base):
                 warnings.warn(
                     f"Got retry_base instance ({f.__class__.__name__}) as callable argument, "

--- a/tenacity/asyncio/__init__.py
+++ b/tenacity/asyncio/__init__.py
@@ -26,9 +26,15 @@ from tenacity import DoAttempt
 from tenacity import DoSleep
 from tenacity import RetryCallState
 from tenacity import RetryError
+from tenacity import WrappedFnWithRetry
 from tenacity import after_nothing
 from tenacity import before_nothing
 from tenacity import _utils
+
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
 
 # Import all built-in retry strategies for easier usage.
 from .retry import RetryBaseT
@@ -44,6 +50,7 @@ if t.TYPE_CHECKING:
 
 WrappedFnReturnT = t.TypeVar("WrappedFnReturnT")
 WrappedFn = t.TypeVar("WrappedFn", bound=t.Callable[..., t.Awaitable[t.Any]])
+WrappedFnParams = ParamSpec("WrappedFnParams")
 
 
 def _portable_async_sleep(seconds: float) -> t.Awaitable[None]:
@@ -174,26 +181,42 @@ class AsyncRetrying(BaseRetrying):
             else:
                 raise StopAsyncIteration
 
-    def wraps(self, fn: WrappedFn) -> WrappedFn:
+    def wraps(
+        self, fn: t.Callable[WrappedFnParams, t.Awaitable[WrappedFnReturnT]]
+    ) -> WrappedFnWithRetry[
+        WrappedFnParams,
+        t.Coroutine[t.Any, t.Any, WrappedFnReturnT],
+        "AsyncRetrying",
+    ]:
         wrapped = super().wraps(fn)
         # Ensure wrapper is recognized as a coroutine function.
 
         @functools.wraps(
             fn, functools.WRAPPER_ASSIGNMENTS + ("__defaults__", "__kwdefaults__")
         )
-        async def async_wrapped(*args: t.Any, **kwargs: t.Any) -> t.Any:
+        async def async_wrapped(
+            *args: WrappedFnParams.args, **kwargs: WrappedFnParams.kwargs
+        ) -> WrappedFnReturnT:
             # Always create a copy to prevent overwriting the local contexts when
             # calling the same wrapped functions multiple times in the same stack
             copy = self.copy()
-            async_wrapped.statistics = copy.statistics  # type: ignore[attr-defined]
+            wrapped_with_retry.statistics = copy.statistics
             return await copy(fn, *args, **kwargs)
 
+        wrapped_with_retry = t.cast(
+            WrappedFnWithRetry[
+                WrappedFnParams,
+                t.Coroutine[t.Any, t.Any, WrappedFnReturnT],
+                AsyncRetrying,
+            ],
+            async_wrapped,
+        )
         # Preserve attributes
-        async_wrapped.retry = self  # type: ignore[attr-defined]
-        async_wrapped.retry_with = wrapped.retry_with  # type: ignore[attr-defined]
-        async_wrapped.statistics = {}  # type: ignore[attr-defined]
+        wrapped_with_retry.retry = self
+        wrapped_with_retry.retry_with = wrapped.retry_with
+        wrapped_with_retry.statistics = {}
 
-        return async_wrapped  # type: ignore[return-value]
+        return wrapped_with_retry
 
 
 __all__ = [

--- a/test_6.sh
+++ b/test_6.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Test dependencies: pytest, tenacity (base+new), typing_extensions (new), pyright (new only).
+# Dockerfile_6 installs typing_extensions and pyright for offline runs.
+# Local runs need the same tools available ahead of time.
+set -e #
+if [ -z "$1" ]; then #
+    echo "Usage: $0 {base|new}" #
+    exit 1 #
+fi #
+PYTHON_BIN= #
+for candidate in py.exe py python3 python /mnt/c/Windows/py.exe; do #
+    if command -v "$candidate" >/dev/null 2>&1 || [ -x "$candidate" ]; then #
+        if ! "$candidate" -c "import pytest, tenacity" >/dev/null 2>&1; then #
+            continue #
+        fi #
+        if [ "$1" = "new" ]; then #
+            if ! "$candidate" -c "import importlib.util, os, shutil; names = ('pyright', 'pyright.exe', 'pyright.cmd') if os.name == 'nt' else ('pyright',); raise SystemExit(0 if importlib.util.find_spec('pyright') is not None or any(shutil.which(name) for name in names) else 1)" >/dev/null 2>&1; then #
+                continue #
+            fi #
+        fi #
+        PYTHON_BIN="$candidate" #
+        break #
+    fi #
+done #
+if [ -z "$PYTHON_BIN" ]; then #
+    if [ "$1" = "new" ]; then #
+        echo "No python interpreter found with pytest, tenacity, and pyright available" #
+    else #
+        echo "No python interpreter found with pytest and tenacity installed" #
+    fi #
+    exit 1 #
+fi #
+case "$1" in #
+    base) #
+        "$PYTHON_BIN" -m pytest -q tests/test_tenacity.py tests/test_asyncio.py -k "retry_with or wraps or check_type" #
+        ;; #
+    new) #
+        "$PYTHON_BIN" -m pytest -q tests/test_retry_typing_helpers.py #
+        ;; #
+    *) #
+        echo "Usage: $0 {base|new}" #
+        exit 1 #
+        ;; #
+esac #

--- a/tests/test_retry_typing_helpers.py
+++ b/tests/test_retry_typing_helpers.py
@@ -1,0 +1,358 @@
+import asyncio
+import functools
+import importlib.util
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+import pytest
+from tenacity import Retrying
+from tenacity import retry
+from tenacity import RetryError
+from tenacity import stop_after_attempt
+from tenacity import wait_fixed
+from tenacity.asyncio import AsyncRetrying
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SAMPLE_DIR = ROOT / "tests" / "typing_samples"
+UPDATED_WAIT_SECONDS = 0.1
+
+POSITIVE_SAMPLES = [
+    "decorator_factory_async.py",
+    "decorator_factory_sync.py",
+    "decorator_raw_async.py",
+    "decorator_raw_sync.py",
+    "wraps_async.py",
+    "wraps_sync.py",
+]
+
+NEGATIVE_SAMPLES = [
+    "decorator_factory_async_negative.py",
+    "decorator_factory_async_retry_with_negative.py",
+    "decorator_factory_sync_negative.py",
+    "decorator_factory_sync_retry_with_negative.py",
+    "decorator_raw_async_negative.py",
+    "decorator_raw_async_retry_with_negative.py",
+    "decorator_raw_sync_negative.py",
+    "decorator_raw_sync_retry_with_negative.py",
+    "wraps_async_negative.py",
+    "wraps_async_retry_with_negative.py",
+    "wraps_sync_negative.py",
+    "wraps_sync_retry_with_negative.py",
+]
+
+
+def pyright_command():
+    if importlib.util.find_spec("pyright") is not None:
+        return [sys.executable, "-m", "pyright"]
+    if os.name == "nt":
+        candidate_names = ("pyright", "pyright.exe", "pyright.cmd")
+    else:
+        candidate_names = ("pyright",)
+    for name in candidate_names:
+        cli = shutil.which(name)
+        if cli is not None:
+            return [cli]
+    raise AssertionError("pyright must be available as a Python module or CLI")
+
+
+def _sync_noop_sleep(seconds):
+    return None
+
+
+async def _async_noop_sleep(seconds):
+    return None
+
+
+@functools.lru_cache(maxsize=None)
+def run_pyright(sample_name):
+    sample_path = SAMPLE_DIR / sample_name
+    completed = subprocess.run(
+        pyright_command() + ["--outputjson", str(sample_path)],
+        capture_output=True,
+        check=False,
+        cwd=ROOT,
+        text=True,
+    )
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(
+            "pyright did not return JSON\n"
+            f"stdout:\n{completed.stdout}\n"
+            f"stderr:\n{completed.stderr}"
+        ) from exc
+    payload["returncode"] = completed.returncode
+    payload["stderr"] = completed.stderr
+    return payload
+
+
+def error_diagnostics(sample_name):
+    return [
+        diagnostic
+        for diagnostic in run_pyright(sample_name)["generalDiagnostics"]
+        if diagnostic["severity"] == "error"
+    ]
+
+
+def error_messages(sample_name):
+    return [diagnostic["message"] for diagnostic in error_diagnostics(sample_name)]
+
+
+@functools.lru_cache(maxsize=None)
+def expected_error_lines(sample_name):
+    sample_path = SAMPLE_DIR / sample_name
+    marked_lines = {
+        line_number
+        for line_number, line in enumerate(
+            sample_path.read_text(encoding="utf-8").splitlines(), start=1
+        )
+        if "# EXPECTED_PYRIGHT_ERROR" in line
+    }
+    assert marked_lines, f"{sample_name} must mark an expected pyright error line"
+    return marked_lines
+
+
+def error_lines(sample_name):
+    return {
+        diagnostic["range"]["start"]["line"] + 1
+        for diagnostic in error_diagnostics(sample_name)
+    }
+
+
+def format_diagnostics(sample_name):
+    return "\n".join(
+        f"{diagnostic['range']['start']['line'] + 1}: {diagnostic['message']}"
+        for diagnostic in error_diagnostics(sample_name)
+    )
+
+
+@pytest.mark.parametrize("sample_name", POSITIVE_SAMPLES)
+def test_pyright_positive_samples_have_no_errors(sample_name):
+    payload = run_pyright(sample_name)
+    assert payload["returncode"] == 0, "\n".join(error_messages(sample_name))
+
+
+@pytest.mark.parametrize("sample_name", NEGATIVE_SAMPLES)
+def test_pyright_negative_samples_only_fail_for_intended_mismatch(sample_name):
+    payload = run_pyright(sample_name)
+    assert payload["returncode"] != 0
+    assert error_lines(sample_name) == expected_error_lines(sample_name), (
+        "Unexpected pyright error locations:\n" + format_diagnostics(sample_name)
+    )
+
+
+def _build_sync_wrapped(entrypoint):
+    def target(value: int) -> int:
+        return value + 1
+
+    if entrypoint == "decorator_factory":
+
+        @retry(stop=stop_after_attempt(1), wait=wait_fixed(0))
+        def wrapped(value: int) -> int:
+            return value + 1
+
+        return wrapped
+
+    if entrypoint == "decorator_raw":
+        return retry(target)
+
+    if entrypoint == "wraps":
+        return Retrying(stop=stop_after_attempt(1), wait=wait_fixed(0)).wraps(target)
+
+    raise AssertionError(f"unsupported entrypoint: {entrypoint}")
+
+
+def _build_async_wrapped(entrypoint):
+    async def target(value: int) -> int:
+        return value + 1
+
+    if entrypoint == "decorator_factory":
+
+        @retry(stop=stop_after_attempt(1), wait=wait_fixed(0))
+        async def wrapped(value: int) -> int:
+            return value + 1
+
+        return wrapped
+
+    if entrypoint == "decorator_raw":
+        return retry(target)
+
+    if entrypoint == "wraps":
+        return AsyncRetrying(stop=stop_after_attempt(1), wait=wait_fixed(0)).wraps(
+            target
+        )
+
+    raise AssertionError(f"unsupported entrypoint: {entrypoint}")
+
+
+def _build_sync_flaky(entrypoint):
+    attempts = {"count": 0}
+
+    def target() -> int:
+        attempts["count"] += 1
+        if attempts["count"] < 2:
+            raise ValueError("boom")
+        return attempts["count"]
+
+    if entrypoint == "decorator_factory":
+
+        @retry(stop=stop_after_attempt(1), wait=wait_fixed(0))
+        def wrapped() -> int:
+            return target()
+
+        return wrapped, attempts
+
+    if entrypoint == "decorator_raw":
+        return retry(target), attempts
+
+    if entrypoint == "wraps":
+        return Retrying(stop=stop_after_attempt(1), wait=wait_fixed(0)).wraps(target), attempts
+
+    raise AssertionError(f"unsupported entrypoint: {entrypoint}")
+
+
+def _build_async_flaky(entrypoint):
+    attempts = {"count": 0}
+
+    async def target() -> int:
+        attempts["count"] += 1
+        if attempts["count"] < 2:
+            raise ValueError("boom")
+        return attempts["count"]
+
+    if entrypoint == "decorator_factory":
+
+        @retry(stop=stop_after_attempt(1), wait=wait_fixed(0))
+        async def wrapped() -> int:
+            return await target()
+
+        return wrapped, attempts
+
+    if entrypoint == "decorator_raw":
+        return retry(target), attempts
+
+    if entrypoint == "wraps":
+        return AsyncRetrying(stop=stop_after_attempt(1), wait=wait_fixed(0)).wraps(target), attempts
+
+    raise AssertionError(f"unsupported entrypoint: {entrypoint}")
+
+
+@pytest.mark.parametrize("entrypoint", ["decorator_factory", "decorator_raw", "wraps"])
+def test_retry_with_returns_distinct_sync_callable(entrypoint):
+    wrapped = _build_sync_wrapped(entrypoint)
+    reconfigured = wrapped.retry_with(stop=stop_after_attempt(2))
+    chained = reconfigured.retry_with(wait=wait_fixed(3))
+
+    assert reconfigured is not wrapped
+    assert chained is not reconfigured
+    assert chained is not wrapped
+    assert wrapped(1) == 2
+    assert reconfigured(1) == 2
+    assert chained(1) == 2
+
+
+@pytest.mark.parametrize("entrypoint", ["decorator_factory", "decorator_raw", "wraps"])
+def test_retry_with_returns_distinct_async_callable(entrypoint):
+    wrapped = _build_async_wrapped(entrypoint)
+    reconfigured = wrapped.retry_with(stop=stop_after_attempt(2))
+    chained = reconfigured.retry_with(wait=wait_fixed(3))
+
+    assert reconfigured is not wrapped
+    assert chained is not reconfigured
+    assert chained is not wrapped
+    assert asyncio.run(wrapped(1)) == 2
+    assert asyncio.run(reconfigured(1)) == 2
+    assert asyncio.run(chained(1)) == 2
+
+
+@pytest.mark.parametrize("entrypoint", ["decorator_factory", "decorator_raw", "wraps"])
+def test_retry_with_updated_stop_takes_effect_sync(entrypoint):
+    wrapped, attempts = _build_sync_flaky(entrypoint)
+
+    attempts["count"] = 0
+    if entrypoint == "decorator_raw":
+        assert wrapped() == 2
+        assert attempts["count"] == 2
+
+        attempts["count"] = 0
+        reconfigured = wrapped.retry_with(stop=stop_after_attempt(1))
+
+        with pytest.raises(RetryError):
+            reconfigured()
+        assert attempts["count"] == 1
+        return
+
+    with pytest.raises(RetryError):
+        wrapped()
+    assert attempts["count"] == 1
+
+    attempts["count"] = 0
+    reconfigured = wrapped.retry_with(stop=stop_after_attempt(2))
+
+    assert reconfigured() == 2
+    assert attempts["count"] == 2
+
+
+@pytest.mark.parametrize("entrypoint", ["decorator_factory", "decorator_raw", "wraps"])
+def test_retry_with_updated_wait_takes_effect_sync(entrypoint):
+    wrapped, attempts = _build_sync_flaky(entrypoint)
+    wait_reconfigured = wrapped.retry_with(
+        stop=stop_after_attempt(2),
+        wait=wait_fixed(UPDATED_WAIT_SECONDS),
+        sleep=_sync_noop_sleep,
+    )
+
+    assert wait_reconfigured() == 2
+    assert attempts["count"] == 2
+    assert wait_reconfigured.statistics["idle_for"] == pytest.approx(
+        UPDATED_WAIT_SECONDS
+    )
+
+
+@pytest.mark.parametrize("entrypoint", ["decorator_factory", "decorator_raw", "wraps"])
+def test_retry_with_updated_stop_takes_effect_async(entrypoint):
+    wrapped, attempts = _build_async_flaky(entrypoint)
+
+    attempts["count"] = 0
+    if entrypoint == "decorator_raw":
+        assert asyncio.run(wrapped()) == 2
+        assert attempts["count"] == 2
+
+        attempts["count"] = 0
+        reconfigured = wrapped.retry_with(stop=stop_after_attempt(1))
+
+        with pytest.raises(RetryError):
+            asyncio.run(reconfigured())
+        assert attempts["count"] == 1
+        return
+
+    with pytest.raises(RetryError):
+        asyncio.run(wrapped())
+    assert attempts["count"] == 1
+
+    attempts["count"] = 0
+    reconfigured = wrapped.retry_with(stop=stop_after_attempt(2))
+
+    assert asyncio.run(reconfigured()) == 2
+    assert attempts["count"] == 2
+
+
+@pytest.mark.parametrize("entrypoint", ["decorator_factory", "decorator_raw", "wraps"])
+def test_retry_with_updated_wait_takes_effect_async(entrypoint):
+    wrapped, attempts = _build_async_flaky(entrypoint)
+    wait_reconfigured = wrapped.retry_with(
+        stop=stop_after_attempt(2),
+        wait=wait_fixed(UPDATED_WAIT_SECONDS),
+        sleep=_async_noop_sleep,
+    )
+
+    assert asyncio.run(wait_reconfigured()) == 2
+    assert attempts["count"] == 2
+    assert wait_reconfigured.statistics["idle_for"] == pytest.approx(
+        UPDATED_WAIT_SECONDS
+    )

--- a/tests/typing_samples/decorator_factory_async.py
+++ b/tests/typing_samples/decorator_factory_async.py
@@ -1,0 +1,68 @@
+# pyright: strict
+
+from typing import Any
+from typing import Callable
+from typing import Coroutine
+from typing_extensions import assert_type
+
+from tenacity import retry
+from tenacity import stop_after_attempt
+from tenacity import wait_fixed
+from tenacity.asyncio import AsyncRetrying
+
+
+def takes_async(fn: Callable[[int, str], Coroutine[Any, Any, str]]) -> Coroutine[Any, Any, str]:
+    return fn(1, "alpha")
+
+
+def controller_name(value: AsyncRetrying) -> str:
+    return value.__class__.__name__
+
+
+def count_entries(value: dict[str, Any]) -> int:
+    return len(value)
+
+
+def consume_async_result(value: Coroutine[Any, Any, str]) -> None:
+    pass
+
+
+@retry(stop=stop_after_attempt(1), wait=wait_fixed(0))
+async def wrapped(count: int, text: str) -> str:
+    return f"{count}:{text}"
+
+
+controller_name_result = controller_name(wrapped.retry)
+stats_size_result = count_entries(wrapped.statistics)
+call_result = wrapped(2, "beta")
+callable_result = takes_async(wrapped)
+
+configured = wrapped.retry_with(stop=stop_after_attempt(2))
+configured_controller_name_result = controller_name(configured.retry)
+configured_stats_size_result = count_entries(configured.statistics)
+configured_call_result = configured(3, "gamma")
+configured_callable_result = takes_async(configured)
+reconfigured = configured.retry_with(wait=wait_fixed(3))
+reconfigured_controller_name_result = controller_name(reconfigured.retry)
+reconfigured_stats_size_result = count_entries(reconfigured.statistics)
+reconfigured_call_result = reconfigured(4, "delta")
+reconfigured_callable_result = takes_async(reconfigured)
+
+assert_type(wrapped.retry, AsyncRetrying)
+assert_type(wrapped.statistics, dict[str, Any])
+consume_async_result(call_result)
+consume_async_result(callable_result)
+assert_type(controller_name_result, str)
+assert_type(stats_size_result, int)
+assert_type(configured.retry, AsyncRetrying)
+assert_type(configured.statistics, dict[str, Any])
+consume_async_result(configured_call_result)
+consume_async_result(configured_callable_result)
+assert_type(configured_controller_name_result, str)
+assert_type(configured_stats_size_result, int)
+assert_type(reconfigured.retry, AsyncRetrying)
+assert_type(reconfigured.statistics, dict[str, Any])
+consume_async_result(reconfigured_call_result)
+consume_async_result(reconfigured_callable_result)
+assert_type(reconfigured_controller_name_result, str)
+assert_type(reconfigured_stats_size_result, int)

--- a/tests/typing_samples/decorator_factory_async_negative.py
+++ b/tests/typing_samples/decorator_factory_async_negative.py
@@ -1,0 +1,20 @@
+# pyright: strict
+
+from typing import Any
+from typing import Callable
+from typing import Coroutine
+from typing_extensions import assert_type
+
+from tenacity import retry
+from tenacity import stop_after_attempt
+from tenacity import wait_fixed
+from tenacity.asyncio import AsyncRetrying
+
+
+@retry(stop=stop_after_attempt(1), wait=wait_fixed(0))
+async def wrapped(count: int, text: str) -> str:
+    return f"{count}:{text}"
+
+
+assert_type(wrapped.retry, AsyncRetrying)
+wrong_wrapped: Callable[[str, int], Coroutine[Any, Any, str]] = wrapped  # EXPECTED_PYRIGHT_ERROR

--- a/tests/typing_samples/decorator_factory_async_retry_with_negative.py
+++ b/tests/typing_samples/decorator_factory_async_retry_with_negative.py
@@ -1,0 +1,21 @@
+# pyright: strict
+
+from typing import Any
+from typing import Callable
+from typing import Coroutine
+from typing_extensions import assert_type
+
+from tenacity import retry
+from tenacity import stop_after_attempt
+from tenacity import wait_fixed
+from tenacity.asyncio import AsyncRetrying
+
+
+@retry(stop=stop_after_attempt(1), wait=wait_fixed(0))
+async def wrapped(count: int, text: str) -> str:
+    return f"{count}:{text}"
+
+
+configured = wrapped.retry_with(stop=stop_after_attempt(2))
+assert_type(configured.retry, AsyncRetrying)
+wrong_configured: Callable[[str, int], Coroutine[Any, Any, str]] = configured  # EXPECTED_PYRIGHT_ERROR

--- a/tests/typing_samples/decorator_factory_sync.py
+++ b/tests/typing_samples/decorator_factory_sync.py
@@ -1,0 +1,63 @@
+# pyright: strict
+
+from typing import Any
+from typing import Callable
+from typing_extensions import assert_type
+
+from tenacity import Retrying
+from tenacity import retry
+from tenacity import stop_after_attempt
+from tenacity import wait_fixed
+
+
+def takes_sync(fn: Callable[[int, str], str]) -> str:
+    return fn(1, "alpha")
+
+
+def controller_name(value: Retrying) -> str:
+    return value.__class__.__name__
+
+
+def count_entries(value: dict[str, Any]) -> int:
+    return len(value)
+
+
+@retry(stop=stop_after_attempt(1), wait=wait_fixed(0))
+def wrapped(count: int, text: str) -> str:
+    return f"{count}:{text}"
+
+
+controller_name_result = controller_name(wrapped.retry)
+stats_size_result = count_entries(wrapped.statistics)
+call_result = wrapped(2, "beta")
+callable_result = takes_sync(wrapped)
+
+configured = wrapped.retry_with(stop=stop_after_attempt(2))
+configured_controller_name_result = controller_name(configured.retry)
+configured_stats_size_result = count_entries(configured.statistics)
+configured_call_result = configured(3, "gamma")
+configured_callable_result = takes_sync(configured)
+reconfigured = configured.retry_with(wait=wait_fixed(3))
+reconfigured_controller_name_result = controller_name(reconfigured.retry)
+reconfigured_stats_size_result = count_entries(reconfigured.statistics)
+reconfigured_call_result = reconfigured(4, "delta")
+reconfigured_callable_result = takes_sync(reconfigured)
+
+assert_type(wrapped.retry, Retrying)
+assert_type(wrapped.statistics, dict[str, Any])
+assert_type(call_result, str)
+assert_type(callable_result, str)
+assert_type(controller_name_result, str)
+assert_type(stats_size_result, int)
+assert_type(configured.retry, Retrying)
+assert_type(configured.statistics, dict[str, Any])
+assert_type(configured_call_result, str)
+assert_type(configured_callable_result, str)
+assert_type(configured_controller_name_result, str)
+assert_type(configured_stats_size_result, int)
+assert_type(reconfigured.retry, Retrying)
+assert_type(reconfigured.statistics, dict[str, Any])
+assert_type(reconfigured_call_result, str)
+assert_type(reconfigured_callable_result, str)
+assert_type(reconfigured_controller_name_result, str)
+assert_type(reconfigured_stats_size_result, int)

--- a/tests/typing_samples/decorator_factory_sync_negative.py
+++ b/tests/typing_samples/decorator_factory_sync_negative.py
@@ -1,0 +1,18 @@
+# pyright: strict
+
+from typing import Callable
+from typing_extensions import assert_type
+
+from tenacity import Retrying
+from tenacity import retry
+from tenacity import stop_after_attempt
+from tenacity import wait_fixed
+
+
+@retry(stop=stop_after_attempt(1), wait=wait_fixed(0))
+def wrapped(count: int, text: str) -> str:
+    return f"{count}:{text}"
+
+
+assert_type(wrapped.retry, Retrying)
+wrong_wrapped: Callable[[str, int], str] = wrapped  # EXPECTED_PYRIGHT_ERROR

--- a/tests/typing_samples/decorator_factory_sync_retry_with_negative.py
+++ b/tests/typing_samples/decorator_factory_sync_retry_with_negative.py
@@ -1,0 +1,19 @@
+# pyright: strict
+
+from typing import Callable
+from typing_extensions import assert_type
+
+from tenacity import Retrying
+from tenacity import retry
+from tenacity import stop_after_attempt
+from tenacity import wait_fixed
+
+
+@retry(stop=stop_after_attempt(1), wait=wait_fixed(0))
+def wrapped(count: int, text: str) -> str:
+    return f"{count}:{text}"
+
+
+configured = wrapped.retry_with(stop=stop_after_attempt(2))
+assert_type(configured.retry, Retrying)
+wrong_configured: Callable[[str, int], str] = configured  # EXPECTED_PYRIGHT_ERROR

--- a/tests/typing_samples/decorator_raw_async.py
+++ b/tests/typing_samples/decorator_raw_async.py
@@ -1,0 +1,69 @@
+# pyright: strict
+
+from typing import Any
+from typing import Callable
+from typing import Coroutine
+from typing_extensions import assert_type
+
+from tenacity import retry
+from tenacity import stop_after_attempt
+from tenacity import wait_fixed
+from tenacity.asyncio import AsyncRetrying
+
+
+def takes_async(fn: Callable[[int, str], Coroutine[Any, Any, str]]) -> Coroutine[Any, Any, str]:
+    return fn(1, "alpha")
+
+
+def controller_name(value: AsyncRetrying) -> str:
+    return value.__class__.__name__
+
+
+def count_entries(value: dict[str, Any]) -> int:
+    return len(value)
+
+
+def consume_async_result(value: Coroutine[Any, Any, str]) -> None:
+    pass
+
+
+async def base(count: int, text: str) -> str:
+    return f"{count}:{text}"
+
+
+wrapped = retry(base)
+
+controller_name_result = controller_name(wrapped.retry)
+stats_size_result = count_entries(wrapped.statistics)
+call_result = wrapped(2, "beta")
+callable_result = takes_async(wrapped)
+
+configured = wrapped.retry_with(stop=stop_after_attempt(2))
+configured_controller_name_result = controller_name(configured.retry)
+configured_stats_size_result = count_entries(configured.statistics)
+configured_call_result = configured(3, "gamma")
+configured_callable_result = takes_async(configured)
+reconfigured = configured.retry_with(wait=wait_fixed(3))
+reconfigured_controller_name_result = controller_name(reconfigured.retry)
+reconfigured_stats_size_result = count_entries(reconfigured.statistics)
+reconfigured_call_result = reconfigured(4, "delta")
+reconfigured_callable_result = takes_async(reconfigured)
+
+assert_type(wrapped.retry, AsyncRetrying)
+assert_type(wrapped.statistics, dict[str, Any])
+consume_async_result(call_result)
+consume_async_result(callable_result)
+assert_type(controller_name_result, str)
+assert_type(stats_size_result, int)
+assert_type(configured.retry, AsyncRetrying)
+assert_type(configured.statistics, dict[str, Any])
+consume_async_result(configured_call_result)
+consume_async_result(configured_callable_result)
+assert_type(configured_controller_name_result, str)
+assert_type(configured_stats_size_result, int)
+assert_type(reconfigured.retry, AsyncRetrying)
+assert_type(reconfigured.statistics, dict[str, Any])
+consume_async_result(reconfigured_call_result)
+consume_async_result(reconfigured_callable_result)
+assert_type(reconfigured_controller_name_result, str)
+assert_type(reconfigured_stats_size_result, int)

--- a/tests/typing_samples/decorator_raw_async_negative.py
+++ b/tests/typing_samples/decorator_raw_async_negative.py
@@ -1,0 +1,18 @@
+# pyright: strict
+
+from typing import Any
+from typing import Callable
+from typing import Coroutine
+from typing_extensions import assert_type
+
+from tenacity import retry
+from tenacity.asyncio import AsyncRetrying
+
+
+async def base(count: int, text: str) -> str:
+    return f"{count}:{text}"
+
+
+wrapped = retry(base)
+assert_type(wrapped.retry, AsyncRetrying)
+wrong_wrapped: Callable[[str, int], Coroutine[Any, Any, str]] = wrapped  # EXPECTED_PYRIGHT_ERROR

--- a/tests/typing_samples/decorator_raw_async_retry_with_negative.py
+++ b/tests/typing_samples/decorator_raw_async_retry_with_negative.py
@@ -1,0 +1,20 @@
+# pyright: strict
+
+from typing import Any
+from typing import Callable
+from typing import Coroutine
+from typing_extensions import assert_type
+
+from tenacity import retry
+from tenacity import stop_after_attempt
+from tenacity.asyncio import AsyncRetrying
+
+
+async def base(count: int, text: str) -> str:
+    return f"{count}:{text}"
+
+
+wrapped = retry(base)
+configured = wrapped.retry_with(stop=stop_after_attempt(2))
+assert_type(configured.retry, AsyncRetrying)
+wrong_configured: Callable[[str, int], Coroutine[Any, Any, str]] = configured  # EXPECTED_PYRIGHT_ERROR

--- a/tests/typing_samples/decorator_raw_sync.py
+++ b/tests/typing_samples/decorator_raw_sync.py
@@ -1,0 +1,64 @@
+# pyright: strict
+
+from typing import Any
+from typing import Callable
+from typing_extensions import assert_type
+
+from tenacity import Retrying
+from tenacity import retry
+from tenacity import stop_after_attempt
+from tenacity import wait_fixed
+
+
+def takes_sync(fn: Callable[[int, str], str]) -> str:
+    return fn(1, "alpha")
+
+
+def controller_name(value: Retrying) -> str:
+    return value.__class__.__name__
+
+
+def count_entries(value: dict[str, Any]) -> int:
+    return len(value)
+
+
+def base(count: int, text: str) -> str:
+    return f"{count}:{text}"
+
+
+wrapped = retry(base)
+
+controller_name_result = controller_name(wrapped.retry)
+stats_size_result = count_entries(wrapped.statistics)
+call_result = wrapped(2, "beta")
+callable_result = takes_sync(wrapped)
+
+configured = wrapped.retry_with(stop=stop_after_attempt(2))
+configured_controller_name_result = controller_name(configured.retry)
+configured_stats_size_result = count_entries(configured.statistics)
+configured_call_result = configured(3, "gamma")
+configured_callable_result = takes_sync(configured)
+reconfigured = configured.retry_with(wait=wait_fixed(3))
+reconfigured_controller_name_result = controller_name(reconfigured.retry)
+reconfigured_stats_size_result = count_entries(reconfigured.statistics)
+reconfigured_call_result = reconfigured(4, "delta")
+reconfigured_callable_result = takes_sync(reconfigured)
+
+assert_type(wrapped.retry, Retrying)
+assert_type(wrapped.statistics, dict[str, Any])
+assert_type(call_result, str)
+assert_type(callable_result, str)
+assert_type(controller_name_result, str)
+assert_type(stats_size_result, int)
+assert_type(configured.retry, Retrying)
+assert_type(configured.statistics, dict[str, Any])
+assert_type(configured_call_result, str)
+assert_type(configured_callable_result, str)
+assert_type(configured_controller_name_result, str)
+assert_type(configured_stats_size_result, int)
+assert_type(reconfigured.retry, Retrying)
+assert_type(reconfigured.statistics, dict[str, Any])
+assert_type(reconfigured_call_result, str)
+assert_type(reconfigured_callable_result, str)
+assert_type(reconfigured_controller_name_result, str)
+assert_type(reconfigured_stats_size_result, int)

--- a/tests/typing_samples/decorator_raw_sync_negative.py
+++ b/tests/typing_samples/decorator_raw_sync_negative.py
@@ -1,0 +1,16 @@
+# pyright: strict
+
+from typing import Callable
+from typing_extensions import assert_type
+
+from tenacity import Retrying
+from tenacity import retry
+
+
+def base(count: int, text: str) -> str:
+    return f"{count}:{text}"
+
+
+wrapped = retry(base)
+assert_type(wrapped.retry, Retrying)
+wrong_wrapped: Callable[[str, int], str] = wrapped  # EXPECTED_PYRIGHT_ERROR

--- a/tests/typing_samples/decorator_raw_sync_retry_with_negative.py
+++ b/tests/typing_samples/decorator_raw_sync_retry_with_negative.py
@@ -1,0 +1,18 @@
+# pyright: strict
+
+from typing import Callable
+from typing_extensions import assert_type
+
+from tenacity import Retrying
+from tenacity import retry
+from tenacity import stop_after_attempt
+
+
+def base(count: int, text: str) -> str:
+    return f"{count}:{text}"
+
+
+wrapped = retry(base)
+configured = wrapped.retry_with(stop=stop_after_attempt(2))
+assert_type(configured.retry, Retrying)
+wrong_configured: Callable[[str, int], str] = configured  # EXPECTED_PYRIGHT_ERROR

--- a/tests/typing_samples/wraps_async.py
+++ b/tests/typing_samples/wraps_async.py
@@ -1,0 +1,68 @@
+# pyright: strict
+
+from typing import Any
+from typing import Callable
+from typing import Coroutine
+from typing_extensions import assert_type
+
+from tenacity import stop_after_attempt
+from tenacity import wait_fixed
+from tenacity.asyncio import AsyncRetrying
+
+
+def takes_async(fn: Callable[[int, str], Coroutine[Any, Any, str]]) -> Coroutine[Any, Any, str]:
+    return fn(1, "alpha")
+
+
+def controller_name(value: AsyncRetrying) -> str:
+    return value.__class__.__name__
+
+
+def count_entries(value: dict[str, Any]) -> int:
+    return len(value)
+
+
+def consume_async_result(value: Coroutine[Any, Any, str]) -> None:
+    pass
+
+
+async def base(count: int, text: str) -> str:
+    return f"{count}:{text}"
+
+
+wrapped = AsyncRetrying(stop=stop_after_attempt(1), wait=wait_fixed(0)).wraps(base)
+
+controller_name_result = controller_name(wrapped.retry)
+stats_size_result = count_entries(wrapped.statistics)
+call_result = wrapped(2, "beta")
+callable_result = takes_async(wrapped)
+
+configured = wrapped.retry_with(stop=stop_after_attempt(2))
+configured_controller_name_result = controller_name(configured.retry)
+configured_stats_size_result = count_entries(configured.statistics)
+configured_call_result = configured(3, "gamma")
+configured_callable_result = takes_async(configured)
+reconfigured = configured.retry_with(wait=wait_fixed(3))
+reconfigured_controller_name_result = controller_name(reconfigured.retry)
+reconfigured_stats_size_result = count_entries(reconfigured.statistics)
+reconfigured_call_result = reconfigured(4, "delta")
+reconfigured_callable_result = takes_async(reconfigured)
+
+assert_type(wrapped.retry, AsyncRetrying)
+assert_type(wrapped.statistics, dict[str, Any])
+consume_async_result(call_result)
+consume_async_result(callable_result)
+assert_type(controller_name_result, str)
+assert_type(stats_size_result, int)
+assert_type(configured.retry, AsyncRetrying)
+assert_type(configured.statistics, dict[str, Any])
+consume_async_result(configured_call_result)
+consume_async_result(configured_callable_result)
+assert_type(configured_controller_name_result, str)
+assert_type(configured_stats_size_result, int)
+assert_type(reconfigured.retry, AsyncRetrying)
+assert_type(reconfigured.statistics, dict[str, Any])
+consume_async_result(reconfigured_call_result)
+consume_async_result(reconfigured_callable_result)
+assert_type(reconfigured_controller_name_result, str)
+assert_type(reconfigured_stats_size_result, int)

--- a/tests/typing_samples/wraps_async_negative.py
+++ b/tests/typing_samples/wraps_async_negative.py
@@ -1,0 +1,19 @@
+# pyright: strict
+
+from typing import Any
+from typing import Callable
+from typing import Coroutine
+from typing_extensions import assert_type
+
+from tenacity import stop_after_attempt
+from tenacity import wait_fixed
+from tenacity.asyncio import AsyncRetrying
+
+
+async def base(count: int, text: str) -> str:
+    return f"{count}:{text}"
+
+
+wrapped = AsyncRetrying(stop=stop_after_attempt(1), wait=wait_fixed(0)).wraps(base)
+assert_type(wrapped.retry, AsyncRetrying)
+wrong_wrapped: Callable[[str, int], Coroutine[Any, Any, str]] = wrapped  # EXPECTED_PYRIGHT_ERROR

--- a/tests/typing_samples/wraps_async_retry_with_negative.py
+++ b/tests/typing_samples/wraps_async_retry_with_negative.py
@@ -1,0 +1,20 @@
+# pyright: strict
+
+from typing import Any
+from typing import Callable
+from typing import Coroutine
+from typing_extensions import assert_type
+
+from tenacity import stop_after_attempt
+from tenacity import wait_fixed
+from tenacity.asyncio import AsyncRetrying
+
+
+async def base(count: int, text: str) -> str:
+    return f"{count}:{text}"
+
+
+wrapped = AsyncRetrying(stop=stop_after_attempt(1), wait=wait_fixed(0)).wraps(base)
+configured = wrapped.retry_with(stop=stop_after_attempt(2))
+assert_type(configured.retry, AsyncRetrying)
+wrong_configured: Callable[[str, int], Coroutine[Any, Any, str]] = configured  # EXPECTED_PYRIGHT_ERROR

--- a/tests/typing_samples/wraps_sync.py
+++ b/tests/typing_samples/wraps_sync.py
@@ -1,0 +1,63 @@
+# pyright: strict
+
+from typing import Any
+from typing import Callable
+from typing_extensions import assert_type
+
+from tenacity import Retrying
+from tenacity import stop_after_attempt
+from tenacity import wait_fixed
+
+
+def takes_sync(fn: Callable[[int, str], str]) -> str:
+    return fn(1, "alpha")
+
+
+def controller_name(value: Retrying) -> str:
+    return value.__class__.__name__
+
+
+def count_entries(value: dict[str, Any]) -> int:
+    return len(value)
+
+
+def base(count: int, text: str) -> str:
+    return f"{count}:{text}"
+
+
+wrapped = Retrying(stop=stop_after_attempt(1), wait=wait_fixed(0)).wraps(base)
+
+controller_name_result = controller_name(wrapped.retry)
+stats_size_result = count_entries(wrapped.statistics)
+call_result = wrapped(2, "beta")
+callable_result = takes_sync(wrapped)
+
+configured = wrapped.retry_with(stop=stop_after_attempt(2))
+configured_controller_name_result = controller_name(configured.retry)
+configured_stats_size_result = count_entries(configured.statistics)
+configured_call_result = configured(3, "gamma")
+configured_callable_result = takes_sync(configured)
+reconfigured = configured.retry_with(wait=wait_fixed(3))
+reconfigured_controller_name_result = controller_name(reconfigured.retry)
+reconfigured_stats_size_result = count_entries(reconfigured.statistics)
+reconfigured_call_result = reconfigured(4, "delta")
+reconfigured_callable_result = takes_sync(reconfigured)
+
+assert_type(wrapped.retry, Retrying)
+assert_type(wrapped.statistics, dict[str, Any])
+assert_type(call_result, str)
+assert_type(callable_result, str)
+assert_type(controller_name_result, str)
+assert_type(stats_size_result, int)
+assert_type(configured.retry, Retrying)
+assert_type(configured.statistics, dict[str, Any])
+assert_type(configured_call_result, str)
+assert_type(configured_callable_result, str)
+assert_type(configured_controller_name_result, str)
+assert_type(configured_stats_size_result, int)
+assert_type(reconfigured.retry, Retrying)
+assert_type(reconfigured.statistics, dict[str, Any])
+assert_type(reconfigured_call_result, str)
+assert_type(reconfigured_callable_result, str)
+assert_type(reconfigured_controller_name_result, str)
+assert_type(reconfigured_stats_size_result, int)

--- a/tests/typing_samples/wraps_sync_negative.py
+++ b/tests/typing_samples/wraps_sync_negative.py
@@ -1,0 +1,17 @@
+# pyright: strict
+
+from typing import Callable
+from typing_extensions import assert_type
+
+from tenacity import Retrying
+from tenacity import stop_after_attempt
+from tenacity import wait_fixed
+
+
+def base(count: int, text: str) -> str:
+    return f"{count}:{text}"
+
+
+wrapped = Retrying(stop=stop_after_attempt(1), wait=wait_fixed(0)).wraps(base)
+assert_type(wrapped.retry, Retrying)
+wrong_wrapped: Callable[[str, int], str] = wrapped  # EXPECTED_PYRIGHT_ERROR

--- a/tests/typing_samples/wraps_sync_retry_with_negative.py
+++ b/tests/typing_samples/wraps_sync_retry_with_negative.py
@@ -1,0 +1,18 @@
+# pyright: strict
+
+from typing import Callable
+from typing_extensions import assert_type
+
+from tenacity import Retrying
+from tenacity import stop_after_attempt
+from tenacity import wait_fixed
+
+
+def base(count: int, text: str) -> str:
+    return f"{count}:{text}"
+
+
+wrapped = Retrying(stop=stop_after_attempt(1), wait=wait_fixed(0)).wraps(base)
+configured = wrapped.retry_with(stop=stop_after_attempt(2))
+assert_type(configured.retry, Retrying)
+wrong_configured: Callable[[str, int], str] = configured  # EXPECTED_PYRIGHT_ERROR


### PR DESCRIPTION
## Summary
- preserve wrapped callable signatures across retry(), retry(fn), and wraps()
- type the retry and statistics helper attributes on wrapped callables
- keep retry_with returning a new wrapped callable with updated retry settings

## Testing
- Not run locally in this environment because no usable Python interpreter was available from PowerShell.