### PR TITLE
build: remove deprecated license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ authors = [
 ]
 classifiers = [
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
## Summary

Removes the deprecated `License :: OSI Approved :: Apache Software License` classifier from `pyproject.toml`.

## Motivation

Since `license = "Apache-2.0"` is already set as an SPDX license expression, the license classifier is redundant and triggers a `SetuptoolsDeprecationWarning` during wheel builds:

```
SetuptoolsDeprecationWarning: License classifiers are deprecated.
Please consider removing the following classifiers in favor of a SPDX license expression:
License :: OSI Approved :: Apache Software License
```

Per [PEP 639](https://peps.python.org/pep-0639/) and the [packaging guide](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license), the SPDX license expression is the modern, preferred approach.

Fixes #523