### PR TITLE
fix: reraise underlying exception when TryAgain wraps a cause

### DIFF
--- a/releasenotes/notes/fix-reraise-tryagain-underlying-exc-e21a26ee95bad0b3.yaml
+++ b/releasenotes/notes/fix-reraise-tryagain-underlying-exc-e21a26ee95bad0b3.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    When ``reraise=True`` and ``TryAgain`` is raised from within an ``except``
+    block, the underlying exception that triggered the retry is now reraised
+    once attempts are exhausted, instead of the opaque ``TryAgain`` sentinel.
+    A bare ``TryAgain`` raised without an active exception keeps reraising
+    ``TryAgain`` as before.

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -185,6 +185,14 @@ class RetryError(Exception):
 
     def reraise(self) -> t.NoReturn:
         if self.last_attempt.failed:
+            exc = self.last_attempt.exception()
+            # When the user explicitly raises TryAgain (typically from within
+            # an "except" block), surface the underlying exception that caused
+            # the retry rather than the opaque TryAgain sentinel.
+            if isinstance(exc, TryAgain):
+                cause = exc.__cause__ or exc.__context__
+                if cause is not None:
+                    raise cause
             raise self.last_attempt.result()
         raise self
 

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -192,7 +192,7 @@ class RetryError(Exception):
             if isinstance(exc, TryAgain):
                 cause = exc.__cause__ or exc.__context__
                 if cause is not None:
-                    raise cause
+                    raise cause.with_traceback(cause.__traceback__) from None
             raise self.last_attempt.result()
         raise self
 

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -239,6 +239,28 @@ class TestContextManager(unittest.TestCase):
             raise Exception
 
     @asynctest
+    async def test_reraise_try_again_with_cause(self) -> None:
+        # When TryAgain is raised from within an "except" block, reraise=True
+        # should surface the underlying exception rather than TryAgain itself.
+        class UnderlyingError(Exception):
+            pass
+
+        async def _test() -> None:
+            try:
+                raise UnderlyingError("boom")
+            except UnderlyingError:
+                # Implicit chaining via __context__ is exactly what we test.
+                raise tenacity.TryAgain  # noqa: B904
+
+        retrying = tasyncio.AsyncRetrying(
+            stop=stop_after_attempt(2),
+            retry=tenacity.retry_never,
+            reraise=True,
+        )
+        with pytest.raises(UnderlyingError):
+            await retrying(_test)
+
+    @asynctest
     async def test_sleeps(self) -> None:
         start = current_time_ms()
         try:

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -259,6 +259,7 @@ class TestContextManager(unittest.TestCase):
         )
         with pytest.raises(UnderlyingError):
             await retrying(_test)
+        self.assertEqual(2, retrying.statistics["attempt_number"])
 
     @asynctest
     async def test_sleeps(self) -> None:

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -892,6 +892,7 @@ class TestRetryConditions(unittest.TestCase):
             reraise=True,
         )
         self.assertRaises(UnderlyingError, r, _r)
+        self.assertEqual(5, r.statistics["attempt_number"])
 
     def test_retry_try_again_forever_reraise(self) -> None:
         def _r() -> None:

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -857,6 +857,42 @@ class TestRetryConditions(unittest.TestCase):
         self.assertRaises(tenacity.RetryError, r, _r)
         self.assertEqual(5, r.statistics["attempt_number"])
 
+    def test_retry_try_again_with_cause_reraise(self) -> None:
+        # When TryAgain is raised from within an "except" block, reraise=True
+        # should surface the underlying exception rather than TryAgain itself.
+        class UnderlyingError(Exception):
+            pass
+
+        def _r() -> None:
+            try:
+                raise UnderlyingError("boom")
+            except UnderlyingError:
+                # Implicit chaining via __context__ is exactly what we test.
+                raise tenacity.TryAgain  # noqa: B904
+
+        r = Retrying(
+            stop=tenacity.stop_after_attempt(5),
+            retry=tenacity.retry_never,
+            reraise=True,
+        )
+        self.assertRaises(UnderlyingError, r, _r)
+        self.assertEqual(5, r.statistics["attempt_number"])
+
+    def test_retry_try_again_from_cause_reraise(self) -> None:
+        # An explicit "raise TryAgain from exc" should also be unwrapped.
+        class UnderlyingError(Exception):
+            pass
+
+        def _r() -> None:
+            raise tenacity.TryAgain from UnderlyingError("boom")
+
+        r = Retrying(
+            stop=tenacity.stop_after_attempt(5),
+            retry=tenacity.retry_never,
+            reraise=True,
+        )
+        self.assertRaises(UnderlyingError, r, _r)
+
     def test_retry_try_again_forever_reraise(self) -> None:
         def _r() -> None:
             raise tenacity.TryAgain


### PR DESCRIPTION
Fixes #544

## Problem

When raising `TryAgain` from within an `except` block to drive a manual retry (e.g. with `retry=retry_never`), `reraise=True` does not behave as expected. Once attempts are exhausted, tenacity reraises the opaque `TryAgain` sentinel instead of the underlying exception that actually caused the retry.

```python
import tenacity
from tenacity import Retrying, stop_after_attempt, retry_never

def call():
    try:
        raise ValueError("the real error")
    except ValueError:
        raise tenacity.TryAgain

Retrying(stop=stop_after_attempt(2), retry=retry_never, reraise=True)(call)
# Raises tenacity.TryAgain, not ValueError
```

## Cause

`RetryError.reraise()` calls `self.last_attempt.result()`, which re-raises whatever exception is stored in the last attempt's future. When the user raised `TryAgain` from inside an `except` block, that stored exception is `TryAgain`, so the underlying error is hidden even though it is available on the exception's `__context__` (or `__cause__` when `raise TryAgain from exc` is used).

## Fix

In `RetryError.reraise()`, when the held exception is a `TryAgain` that carries an underlying cause (`__cause__` or `__context__`), reraise that underlying exception instead. A bare `TryAgain` raised without an active exception still reraises `TryAgain`, preserving the existing behavior covered by `test_retry_try_again_forever_reraise`.

## Tests

Added regression tests for both the sync (`Retrying`) and async (`AsyncRetrying`) paths covering implicit chaining (`raise TryAgain` inside `except`) and explicit chaining (`raise TryAgain from exc`). They fail before the change and pass after. Full suite, `ruff`, and `mypy --strict` are green.