### PR TITLE
fix: respect enabled=False in iterator protocols (__iter__ / __aiter__)

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -475,6 +475,13 @@ class BaseRetrying(ABC):
         self._add_action_func(lambda rs: DoSleep(rs.upcoming_sleep))
 
     def __iter__(self) -> t.Generator[AttemptManager, None, None]:
+        if not self.enabled:
+            retry_state = RetryCallState(self, fn=None, args=(), kwargs={})
+            yield AttemptManager(retry_state=retry_state)
+            if retry_state.outcome is not None and retry_state.outcome.failed:
+                raise retry_state.outcome.exception()  # type: ignore[misc]
+            return
+
         self.begin()
 
         retry_state = RetryCallState(self, fn=None, args=(), kwargs={})

--- a/tenacity/asyncio/__init__.py
+++ b/tenacity/asyncio/__init__.py
@@ -166,11 +166,25 @@ class AsyncRetrying(BaseRetrying):
         raise TypeError("AsyncRetrying object is not iterable")
 
     def __aiter__(self) -> "AsyncRetrying":
+        if not self.enabled:
+            self._retry_state = RetryCallState(self, fn=None, args=(), kwargs={})
+            self._disabled_iter_done = False
+            return self
+
         self.begin()
         self._retry_state = RetryCallState(self, fn=None, args=(), kwargs={})
         return self
 
     async def __anext__(self) -> AttemptManager:
+        if not self.enabled:
+            if self._disabled_iter_done:
+                outcome = self._retry_state.outcome
+                if outcome is not None and outcome.failed:
+                    raise outcome.exception()  # type: ignore[misc]
+                raise StopAsyncIteration
+            self._disabled_iter_done = True
+            return AttemptManager(retry_state=self._retry_state)
+
         while True:
             do = await self.iter(retry_state=self._retry_state)
             if do is None:

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -176,6 +176,35 @@ class TestAsyncEnabled(unittest.TestCase):
             await always_fails()
         assert call_count == 1
 
+    @asynctest
+    async def test_enabled_false_aiter_raises_original_exception(self) -> None:
+        """When enabled=False, the async iterator raises the original exception,
+        not a RetryError, and the body executes exactly once."""
+        call_count = 0
+        retrying = AsyncRetrying(
+            enabled=False,
+            stop=stop_after_attempt(5),
+        )
+        with pytest.raises(ValueError, match="fail"):
+            async for attempt in retrying:
+                with attempt:
+                    call_count += 1
+                    raise ValueError("fail")
+        assert call_count == 1
+
+    @asynctest
+    async def test_enabled_false_aiter_succeeds_on_first_attempt(self) -> None:
+        """When enabled=False, the async iterator runs the body once and stops."""
+        call_count = 0
+        retrying = AsyncRetrying(
+            enabled=False,
+            stop=stop_after_attempt(5),
+        )
+        async for attempt in retrying:
+            with attempt:
+                call_count += 1
+        assert call_count == 1
+
 
 @unittest.skipIf(not have_trio, "trio not installed")
 class TestTrio(unittest.TestCase):

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -1561,6 +1561,35 @@ class TestEnabled:
         assert fails_twice() is True
         assert call_count == 3
 
+    def test_enabled_false_iter_raises_original_exception(self) -> None:
+        """When enabled=False, the iterator protocol raises the original exception,
+        not a RetryError, and the body executes exactly once."""
+        call_count = 0
+        retrying = Retrying(
+            enabled=False,
+            stop=tenacity.stop_after_attempt(5),
+            wait=tenacity.wait_none(),
+        )
+        with pytest.raises(ValueError, match="fail"):
+            for attempt in retrying:
+                with attempt:
+                    call_count += 1
+                    raise ValueError("fail")
+        assert call_count == 1
+
+    def test_enabled_false_iter_succeeds_on_first_attempt(self) -> None:
+        """When enabled=False, the iterator protocol runs the body once and stops."""
+        call_count = 0
+        retrying = Retrying(
+            enabled=False,
+            stop=tenacity.stop_after_attempt(5),
+            wait=tenacity.wait_none(),
+        )
+        for attempt in retrying:
+            with attempt:
+                call_count += 1
+        assert call_count == 1
+
 
 class TestRetryWith:
     def test_redefine_wait(self) -> None:


### PR DESCRIPTION
## Summary

When `Retrying(enabled=False)` is used with the context-manager iterator pattern — `for attempt in retrying:` or `async for attempt in retrying:` — the `enabled` flag is silently ignored and the full retry machinery runs (multiple attempts, stop/wait evaluated). This is inconsistent with the `wraps()`-based path, which already handles `enabled=False` correctly by running the function exactly once and propagating any exception directly.

**Reproducer:**

```python
import tenacity

call_count = 0
retrying = tenacity.Retrying(enabled=False, stop=tenacity.stop_after_attempt(5))
try:
    for attempt in retrying:
        with attempt:
            call_count += 1
            raise ValueError("fail")
except tenacity.RetryError:
    # WRONG: call_count == 5, and a RetryError is raised instead of ValueError
    print(f"call_count={call_count}")  # prints 5, should be 1
```

## Fix

- `BaseRetrying.__iter__`: when `not self.enabled`, yield one `AttemptManager`, then re-raise the stored exception if the attempt failed — mirroring `wraps()`.
- `AsyncRetrying.__aiter__` / `__anext__`: same semantics via a one-shot done-flag.

Four regression tests are added (sync failure, sync success, async failure, async success).

This pull request was prepared with the assistance of AI, under my direction and review.