### PR TITLE
Respect enabled=False on the direct-call path

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -514,6 +514,9 @@ class Retrying(BaseRetrying):
         *args: t.Any,
         **kwargs: t.Any,
     ) -> WrappedFnReturnT:
+        if not self.enabled:
+            return fn(*args, **kwargs)
+
         self.begin()
 
         retry_state = RetryCallState(retry_object=self, fn=fn, args=args, kwargs=kwargs)

--- a/tenacity/asyncio/__init__.py
+++ b/tenacity/asyncio/__init__.py
@@ -111,10 +111,15 @@ class AsyncRetrying(BaseRetrying):
     async def __call__(  # type: ignore[override]
         self, fn: WrappedFn, *args: t.Any, **kwargs: t.Any
     ) -> WrappedFnReturnT:
+        is_async = _utils.is_coroutine_callable(fn)
+        if not self.enabled:
+            if is_async:
+                return await fn(*args, **kwargs)  # type: ignore[misc]
+            return fn(*args, **kwargs)
+
         self.begin()
 
         retry_state = RetryCallState(retry_object=self, fn=fn, args=args, kwargs=kwargs)
-        is_async = _utils.is_coroutine_callable(fn)
         while True:
             do = await self.iter(retry_state=retry_state)
             if isinstance(do, DoAttempt):

--- a/tenacity/asyncio/__init__.py
+++ b/tenacity/asyncio/__init__.py
@@ -114,8 +114,8 @@ class AsyncRetrying(BaseRetrying):
         is_async = _utils.is_coroutine_callable(fn)
         if not self.enabled:
             if is_async:
-                return await fn(*args, **kwargs)  # type: ignore[misc]
-            return fn(*args, **kwargs)
+                return await fn(*args, **kwargs)  # type: ignore[no-any-return]
+            return fn(*args, **kwargs)  # type: ignore[return-value]
 
         self.begin()
 

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -205,6 +205,43 @@ class TestAsyncEnabled(unittest.TestCase):
                 call_count += 1
         assert call_count == 1
 
+    @asynctest
+    async def test_enabled_false_call_raises_original_exception(self) -> None:
+        """When enabled=False, awaiting the controller directly raises the original
+        exception, not a RetryError, and the coroutine executes exactly once."""
+        call_count = 0
+
+        async def always_fails() -> None:
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("fail")
+
+        retrying = AsyncRetrying(
+            enabled=False,
+            stop=stop_after_attempt(5),
+        )
+        with pytest.raises(ValueError, match="fail"):
+            await retrying(always_fails)
+        assert call_count == 1
+
+    @asynctest
+    async def test_enabled_false_call_succeeds_on_first_attempt(self) -> None:
+        """When enabled=False, awaiting the controller directly runs the coroutine
+        once and returns its result."""
+        call_count = 0
+
+        async def succeeds() -> str:
+            nonlocal call_count
+            call_count += 1
+            return "ok"
+
+        retrying = AsyncRetrying(
+            enabled=False,
+            stop=stop_after_attempt(5),
+        )
+        assert await retrying(succeeds) == "ok"
+        assert call_count == 1
+
 
 @unittest.skipIf(not have_trio, "trio not installed")
 class TestTrio(unittest.TestCase):

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -1590,6 +1590,43 @@ class TestEnabled:
                 call_count += 1
         assert call_count == 1
 
+    def test_enabled_false_call_raises_original_exception(self) -> None:
+        """When enabled=False, calling the controller directly raises the original
+        exception, not a RetryError, and the function executes exactly once."""
+        call_count = 0
+
+        def fails() -> None:
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("fail")
+
+        retrying = Retrying(
+            enabled=False,
+            stop=tenacity.stop_after_attempt(5),
+            wait=tenacity.wait_none(),
+        )
+        with pytest.raises(ValueError, match="fail"):
+            retrying(fails)
+        assert call_count == 1
+
+    def test_enabled_false_call_succeeds_on_first_attempt(self) -> None:
+        """When enabled=False, calling the controller directly runs the function once
+        and returns its result."""
+        call_count = 0
+
+        def succeeds() -> str:
+            nonlocal call_count
+            call_count += 1
+            return "ok"
+
+        retrying = Retrying(
+            enabled=False,
+            stop=tenacity.stop_after_attempt(5),
+            wait=tenacity.wait_none(),
+        )
+        assert retrying(succeeds) == "ok"
+        assert call_count == 1
+
 
 class TestRetryWith:
     def test_redefine_wait(self) -> None:


### PR DESCRIPTION
`Retrying(enabled=False)(fn)` and `AsyncRetrying(enabled=False)(fn)` ignore `enabled=False` on the direct-call path — they run the full retry loop and wrap the original exception in `RetryError`, instead of calling the function once and propagating its exception.

PR #643 added the `enabled=False` short-circuit to the iterator protocols (`__iter__`/`__aiter__`/`__anext__`) but the direct-call protocol (`__call__`) was left behind, since `iter()` itself never consults `enabled`. The fix adds the same short-circuit at the top of each `__call__` (awaiting coroutine callables for the async path).

Verified both ways: old runs the function 5× and raises `RetryError` (sync and async); fixed calls once and raises the original `ValueError`, matching the iterator/decorator paths. 154 existing tests green; +4 regression tests (which fail on the unfixed code) → 158 passed.