### PR TITLE
wait_chain: reject empty strategy list with ValueError instead of IndexError

### DIFF
--- a/releasenotes/notes/fix-wait-chain-empty-strategies-d3a8f7c2b1e4f569.yaml
+++ b/releasenotes/notes/fix-wait-chain-empty-strategies-d3a8f7c2b1e4f569.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    ``wait_chain()`` now raises ``ValueError`` at construction time when
+    called with no strategies, instead of raising a confusing
+    ``IndexError`` from ``__call__`` the first time it is used. Empty
+    wait chains have no useful behaviour, so failing early gives a
+    clearer error message.

--- a/tenacity/wait.py
+++ b/tenacity/wait.py
@@ -104,6 +104,8 @@ class wait_chain(wait_base):
     """
 
     def __init__(self, *strategies: wait_base) -> None:
+        if not strategies:
+            raise ValueError("wait_chain() requires at least one strategy")
         self.strategies = strategies
 
     def __call__(self, retry_state: "RetryCallState") -> float:

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -541,10 +541,13 @@ class TestWaitConditions(unittest.TestCase):
         self.assertEqual(sleep_intervals, [1.0, 2.0, 3.0, 3.0])
         sleep_intervals[:] = []
 
-        # Clear and restart retrying.
-        self.assertRaises(tenacity.RetryError, always_return_1)
-        self.assertEqual(sleep_intervals, [1.0, 2.0, 3.0, 3.0])
-        sleep_intervals[:] = []
+    def test_wait_chain_requires_at_least_one_strategy(self) -> None:
+        with self.assertRaises(ValueError):
+            tenacity.wait_chain()
+        # Confirm the wrapped Retrying path surfaces the same ValueError
+        # instead of an opaque IndexError from self.strategies[-1].
+        with self.assertRaises(ValueError):
+            Retrying(wait=tenacity.wait_chain())
 
     def test_wait_random_exponential(self) -> None:
         fn = tenacity.wait_random_exponential(0.5, 60.0)


### PR DESCRIPTION
## Summary

`wait_chain()` accepts a variadic list of wait strategies and stores them in `self.strategies`. When called with no strategies, `self.strategies` ends up as `()`. The first call to `__call__` then evaluates `min(max(1, 1), 0) == 0`, so `self.strategies[wait_func_no - 1]` turns into `self.strategies[-1]` and raises an `IndexError` from inside a running retry.

This is opaque for what is really a programmer error at construction time. An empty `wait_chain` has no useful behaviour, so failing early is friendlier than letting it crash later from a `min(max(1, 1), 0)` corner case.

## Fix

`tenacity/wait.py`: validate in `__init__` and raise `ValueError('wait_chain() requires at least one strategy')` so the failure happens at the point where the bad configuration is created, not later when the wait function is first evaluated.

## Tests

`tests/test_tenacity.py`:

- `test_wait_chain_requires_at_least_one_strategy` — asserts `ValueError` from the bare `wait_chain()` constructor and from the wrapped `Retrying(wait=wait_chain())` path that previously surfaced the `IndexError`.

The change is one validation line plus the test. A release note is included in `releasenotes/notes/`.