### PR TITLE
Accept empty message in retry_if_exception_message

### DIFF
--- a/releasenotes/notes/fix-exception-message-empty-string-7b1e9c4a2f6d0835.yaml
+++ b/releasenotes/notes/fix-exception-message-empty-string-7b1e9c4a2f6d0835.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    ``retry_if_exception_message`` (and its inverse
+    ``retry_if_not_exception_message``) now accept an empty ``message=""``
+    and match exceptions whose ``str()`` is empty, such as a bare
+    ``RuntimeError()``. Previously a truthiness check treated ``message=""``
+    as "no message given" and raised a spurious ``TypeError`` at
+    construction time, making every message matchable except the empty one.

--- a/tenacity/retry.py
+++ b/tenacity/retry.py
@@ -223,22 +223,22 @@ class retry_if_exception_message(retry_if_exception):
         message: str | None = None,
         match: None | str | re.Pattern[str] = None,
     ) -> None:
-        if message and match:
+        if message is not None and match is not None:
             raise TypeError(
                 f"{self.__class__.__name__}() takes either 'message' or 'match', not both"
             )
 
-        if not message and not match:
+        if message is None and match is None:
             raise TypeError(
                 f"{self.__class__.__name__}() missing 1 required argument 'message' or 'match'"
             )
 
         self.message = message
-        self.match = re.compile(match) if match else None
+        self.match = re.compile(match) if match is not None else None
         super().__init__(self._check)
 
     def _check(self, exception: BaseException) -> bool:
-        if self.message:
+        if self.message is not None:
             return self.message == str(exception)
         assert self.match is not None
         return bool(self.match.match(str(exception)))

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -917,6 +917,32 @@ class TestRetryConditions(unittest.TestCase):
         with self.assertRaises(TypeError):
             tenacity.retry_if_exception_message(message="negative", match="negative")
 
+    def test_retry_if_exception_message_empty_message(self) -> None:
+        # An exception whose str() is empty (e.g. a bare ``RuntimeError()``) is
+        # a valid target. ``message=""`` must be accepted and match it, rather
+        # than being treated as "no message given" by a truthiness check.
+        r = tenacity.retry_if_exception_message(message="")
+        self.assertEqual(r.message, "")
+        empty = make_retry_state(
+            1, 0, last_result=tenacity.Future.construct(1, RuntimeError(), True)
+        )
+        nonempty = make_retry_state(
+            1, 0, last_result=tenacity.Future.construct(1, RuntimeError("boom"), True)
+        )
+        self.assertTrue(r(empty))
+        self.assertFalse(r(nonempty))
+
+    def test_retry_if_not_exception_message_empty_message(self) -> None:
+        r = tenacity.retry_if_not_exception_message(message="")
+        empty = make_retry_state(
+            1, 0, last_result=tenacity.Future.construct(1, RuntimeError(), True)
+        )
+        nonempty = make_retry_state(
+            1, 0, last_result=tenacity.Future.construct(1, RuntimeError("boom"), True)
+        )
+        self.assertFalse(r(empty))
+        self.assertTrue(r(nonempty))
+
 
 class NoneReturnUntilAfterCount:
     """Holds counter state for invoking a method several times in a row."""


### PR DESCRIPTION
## Problem

`retry_if_exception_message` validates its two mutually-exclusive arguments
with truthiness checks:

```python
if message and match:            # both given
    raise TypeError(...)
if not message and not match:    # neither given
    raise TypeError(...)
...
self.match = re.compile(match) if match else None
...
def _check(self, exception):
    if self.message:             # skips message == ""
        return self.message == str(exception)
```

An **empty string is a valid message target** — it matches exceptions whose
`str()` is empty, e.g. a bare `raise RuntimeError()` (`str(RuntimeError()) == ""`).
But `not message` is `True` for `""`, so:

```python
retry_if_exception_message(message="")
# TypeError: retry_if_exception_message() missing 1 required argument 'message' or 'match'
```

The result is an asymmetry: you can match *every* exception message **except**
the empty one. `_check`'s `if self.message:` would drop the empty-message branch
as well, falling through to `assert self.match is not None`.

## Fix

Replace the truthiness guards with `is None` checks, so an empty message is
accepted and matched like any other. `retry_if_not_exception_message` inherits
the same constructor and is fixed by the same change.

## Tests

Added `test_retry_if_exception_message_empty_message` and
`test_retry_if_not_exception_message_empty_message`: construct with `message=""`
and drive the predicate against a bare `RuntimeError()` (matches) and a
`RuntimeError("boom")` (does not), plus the inverse for the not-variant. Both
fail before the change (`TypeError` at construction) and pass after. The
existing `test_..._negative_no_inputs` (passing *no* arguments must raise) still
passes.

Full suite: `167 passed, 1 skipped, 12 subtests`. `ruff check` / `ruff format --check` clean.
