### PR TITLE
Avoid unnecessary exponential wait computation

### DIFF
--- a/releasenotes/notes/fix-exponential-max-computation-526.yaml
+++ b/releasenotes/notes/fix-exponential-max-computation-526.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Avoid computing an increasingly large power after ``wait_exponential`` has
+    reached its configured maximum wait.

--- a/tenacity/wait.py
+++ b/tenacity/wait.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import abc
+import math
 import random
 import typing
 import warnings
@@ -201,8 +202,17 @@ class wait_exponential(wait_base):
         self.exp_base = exp_base
 
     def __call__(self, retry_state: "RetryCallState") -> float:
+        exponent = retry_state.attempt_number - 1
+        if (
+            self.multiplier > 0
+            and self.max > 0
+            and self.exp_base > 1
+            and math.isfinite(self.max)
+            and exponent > math.log(self.max / self.multiplier, self.exp_base)
+        ):
+            return max(max(0, self.min), self.max)
         try:
-            exp = self.exp_base ** (retry_state.attempt_number - 1)
+            exp = self.exp_base**exponent
             result = self.multiplier * exp
         except OverflowError:
             return self.max

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -359,6 +359,14 @@ class TestWaitConditions(unittest.TestCase):
         self.assertEqual(r.wait(make_retry_state(8, 0)), 40)
         self.assertEqual(r.wait(make_retry_state(50, 0)), 40)
 
+    def test_exponential_skips_power_after_reaching_max(self) -> None:
+        class ExplodingPower(float):
+            def __pow__(self, exponent: float, modulo: int | None = None) -> float:
+                raise AssertionError("power should not be calculated above the maximum")
+
+        r = Retrying(wait=tenacity.wait_exponential(max=40, exp_base=ExplodingPower(2)))
+        self.assertEqual(r.wait(make_retry_state(50, 0)), 40)
+
     def test_exponential_with_min_wait(self) -> None:
         r = Retrying(wait=tenacity.wait_exponential(min=20))
         self.assertEqual(r.wait(make_retry_state(1, 0)), 20)


### PR DESCRIPTION
`wait_exponential(max=...)` still computes `exp_base ** attempt_number` on every retry after reaching the cap, making each later retry increasingly expensive during long-running polling. This checks the logarithmic threshold first and returns the configured cap without constructing the large integer; the regression test proves the power operation is skipped.

Fixes #526.
