### PR TITLE
Avoid underflow in exponential wait threshold

### DIFF
--- a/releasenotes/notes/fix-exponential-multiplier-underflow-4fd1d6d6b9c8e2a1.yaml
+++ b/releasenotes/notes/fix-exponential-multiplier-underflow-4fd1d6d6b9c8e2a1.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Prevent ``wait_exponential`` from raising ``ValueError`` when dividing the
+    configured maximum wait by a large multiplier underflows to zero.

--- a/tenacity/wait.py
+++ b/tenacity/wait.py
@@ -208,7 +208,9 @@ class wait_exponential(wait_base):
             and self.max > 0
             and self.exp_base > 1
             and math.isfinite(self.max)
-            and exponent > math.log(self.max / self.multiplier, self.exp_base)
+            and exponent
+            > math.log(self.max, self.exp_base)
+            - math.log(self.multiplier, self.exp_base)
         ):
             return max(max(0, self.min), self.max)
         try:

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -367,6 +367,10 @@ class TestWaitConditions(unittest.TestCase):
         r = Retrying(wait=tenacity.wait_exponential(max=40, exp_base=ExplodingPower(2)))
         self.assertEqual(r.wait(make_retry_state(50, 0)), 40)
 
+    def test_exponential_caps_when_max_multiplier_ratio_underflows(self) -> None:
+        r = Retrying(wait=tenacity.wait_exponential(multiplier=1e300, max=1e-100))
+        self.assertEqual(r.wait(make_retry_state(1, 0)), 1e-100)
+
     def test_exponential_with_min_wait(self) -> None:
         r = Retrying(wait=tenacity.wait_exponential(min=20))
         self.assertEqual(r.wait(make_retry_state(1, 0)), 20)


### PR DESCRIPTION
## Summary

`wait_exponential` can raise `ValueError: math domain error` instead of returning a wait time when `multiplier`/`max` are finite and positive but their ratio underflows to `0.0`. It's a regression from the threshold optimization in #654. The fix computes the same threshold as a difference of logarithms so there's no underflowing division.

## How narrow this is

Pretty narrow, and I want to be upfront about it. The crash needs `max / multiplier` to underflow a 64-bit float all the way to `0.0`, i.e. `multiplier` bigger than `max` by more than ~308 orders of magnitude (`wait_exponential(multiplier=1e300, max=1e-100)`), or a non-finite `multiplier`. Everyday configs — `max=0`, `multiplier=0`, any realistic seconds/milliseconds values — already go through the existing guards and are untouched.

I ran into it while checking the #654 change for edge cases, not in production. Sending it because it's a genuine regression in a recently merged optimization and the fix is one line with no behavior change for valid input — not because I think it bites many people. Happy for you to close it if it's below the bar.

## Root cause

The #654 optimization short-circuits to the cap when the exponent would exceed `log(max / multiplier)`. Forming `max / multiplier` first can underflow to `0.0` for extreme finite inputs, and `math.log(0.0)` raises. In that regime the uncapped wait is already past `max`, so the right answer is just `max`.

`log(max) - log(multiplier)` is the same value (`log(a/b) = log(a) - log(b)`) without the underflowing intermediate, so the early-return optimization still holds for every valid input.

## Testing

- `uv run pytest -q` → 172 passed, 12 subtests
- `uv run poe lint`, `uv run poe mypy`, `uv run reno lint` → all pass
- Added a regression test with finite positive values whose ratio underflows.
- Checked 2,160 positive boundary combinations against the pre-optimization direct-power result — 0 differences, so valid inputs are unchanged.
