### PR TITLE
Fix is_coroutine_callable for a partial over an async callable object

### DIFF
--- a/releasenotes/notes/fix-is-coroutine-callable-partial-async-object-3c1f9a2b7e4d6058.yaml
+++ b/releasenotes/notes/fix-is-coroutine-callable-partial-async-object-3c1f9a2b7e4d6058.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Detect a ``functools.partial`` wrapping a callable object whose
+    ``__call__`` is asynchronous as a coroutine callable. Previously such a
+    partial was misrouted to the synchronous retry path, which returned an
+    un-awaited coroutine instead of retrying the awaited call.

--- a/tenacity/_utils.py
+++ b/tenacity/_utils.py
@@ -92,8 +92,12 @@ def is_coroutine_callable(call: typing.Callable[..., typing.Any]) -> bool:
         return False
     if inspect.iscoroutinefunction(call):
         return True
-    partial_call = isinstance(call, functools.partial) and call.func
-    dunder_call = partial_call or getattr(call, "__call__", None)  # noqa: B004
+    if isinstance(call, functools.partial):
+        # Recurse into the wrapped target so a partial over a callable *object*
+        # with an async ``__call__`` (not just a plain coroutine function) is
+        # still detected as a coroutine callable.
+        return is_coroutine_callable(call.func)
+    dunder_call = getattr(call, "__call__", None)  # noqa: B004
     return inspect.iscoroutinefunction(dunder_call)
 
 

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -16,7 +16,7 @@ import asyncio
 import inspect
 import unittest
 from collections.abc import Callable, Coroutine
-from functools import wraps
+from functools import partial, wraps
 from typing import Any, TypeVar
 from unittest import mock
 
@@ -94,6 +94,25 @@ class TestAsyncio(unittest.TestCase):
         retrying = AsyncRetrying()
         await retrying(_async_function, thing)
         assert thing.counter == thing.count
+
+    @asynctest
+    async def test_retry_partial_over_async_callable_object(self) -> None:
+        # A functools.partial wrapping a callable *object* with an async
+        # __call__ must be routed through the async path; otherwise
+        # AsyncRetrying calls it synchronously and stores the un-awaited
+        # coroutine as the result without ever running the body.
+        class AsyncCallable:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def __call__(self) -> str:
+                self.calls += 1
+                return "awaited-result"
+
+        obj = AsyncCallable()
+        result: str = await AsyncRetrying()(partial(obj))
+        assert result == "awaited-result"
+        assert obj.calls == 1
 
     @asynctest
     async def test_stop_after_attempt(self) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,6 +24,8 @@ def test_is_coroutine_callable() -> None:
     partial_sync_func = functools.partial(sync_func)
     partial_async_class = functools.partial(AsyncClass().__call__)
     partial_sync_class = functools.partial(SyncClass().__call__)
+    partial_async_instance = functools.partial(AsyncClass())
+    partial_sync_instance = functools.partial(SyncClass())
     partial_lambda_fn = functools.partial(lambda_fn)
 
     assert _utils.is_coroutine_callable(async_func) is True
@@ -38,6 +40,8 @@ def test_is_coroutine_callable() -> None:
     assert _utils.is_coroutine_callable(partial_sync_func) is False
     assert _utils.is_coroutine_callable(partial_async_class) is True
     assert _utils.is_coroutine_callable(partial_sync_class) is False
+    assert _utils.is_coroutine_callable(partial_async_instance) is True
+    assert _utils.is_coroutine_callable(partial_sync_instance) is False
     assert _utils.is_coroutine_callable(partial_lambda_fn) is False
 
 


### PR DESCRIPTION
## Problem

`is_coroutine_callable` handles a `functools.partial` by pulling out `call.func` and running `iscoroutinefunction()` on it:

```python
partial_call = isinstance(call, functools.partial) and call.func
dunder_call = partial_call or getattr(call, "__call__", None)
return inspect.iscoroutinefunction(dunder_call)
```

When `call.func` is a callable **object** whose `__call__` is `async` (not a plain coroutine function), `iscoroutinefunction()` inspects the *instance* rather than its `__call__`, so the partial is reported as not-async:

```python
class AsyncClient:
    async def __call__(self, x): ...

is_coroutine_callable(AsyncClient())                     # True  (via the __call__ branch)
is_coroutine_callable(functools.partial(AsyncClient()))  # False ❌
```

The same object works when it isn't wrapped in a partial, so `partial(...)` silently breaks a case that otherwise works. The consequence is real: `retry(...)(functools.partial(async_callable_obj, ...))` is routed to the synchronous `Retrying` (`tenacity/__init__.py:752` picks the engine via `is_coroutine_callable`), calls the coroutine without awaiting it, and returns a **leaked, un-awaited coroutine** as the "result" (with a `RuntimeWarning: coroutine ... never awaited`).

## Fix

Recurse into the partial's target. This detects a partial over an async callable object, keeps the existing partial-over-coroutine-function and bare-object cases working, and additionally handles nested partials.

## Test plan

Extended `tests/test_utils.py::test_is_coroutine_callable` with `functools.partial(AsyncClass())` / `functools.partial(SyncClass())` (partial over the *instance*, which the existing `partial(AsyncClass().__call__)` case didn't cover).

- On `main` the new `partial_async_instance` assertion fails; with this change the full file passes.
- `pytest tests/` → 171 passed, 1 skipped.
- `ruff check` / `ruff format --check` / `mypy tenacity/_utils.py` all clean.
- Added a reno release note.

---
Authored with assistance from Claude Code (Anthropic); the bug, fix, and test were reviewed and verified locally by the contributor.