### PR TITLE
Fix retry_if_exception_cause_type infinite loop on cyclic exception cause chains

### DIFF
--- a/tenacity/retry.py
+++ b/tenacity/retry.py
@@ -176,10 +176,12 @@ class retry_if_exception_cause_type(retry_base):
             raise RuntimeError("__call__ called before outcome was set")
 
         if retry_state.outcome.failed:
+            seen: set[int] = set()
             exc = retry_state.outcome.exception()
-            while exc is not None:
+            while exc is not None and id(exc) not in seen:
                 if isinstance(exc.__cause__, self.exception_cause_types):
                     return True
+                seen.add(id(exc))
                 exc = exc.__cause__
 
         return False

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -1441,6 +1441,31 @@ class TestDecoratorWrapper(unittest.TestCase):
         except NameError:
             pass
 
+    def test_retry_if_exception_cause_type_with_cause_cycle(self) -> None:
+        # A cyclic __cause__ chain (e.g. ``raise e from e``) must not hang the
+        # cause scan; the predicate should give up once the chain repeats.
+        def _raise_self_caused() -> None:
+            try:
+                raise ValueError("inner")
+            except ValueError as e:
+                raise e from e
+
+        def _raise_two_node_cycle() -> None:
+            first = KeyError("first")
+            second = OSError("second")
+            first.__cause__ = second
+            second.__cause__ = first
+            raise first
+
+        for raiser in (_raise_self_caused, _raise_two_node_cycle):
+            r = Retrying(
+                retry=tenacity.retry_if_exception_cause_type(NameError),
+                stop=tenacity.stop_after_attempt(2),
+                reraise=True,
+            )
+            with self.assertRaises((ValueError, KeyError)):
+                r(raiser)
+
     def test_retry_preserves_argument_defaults(self) -> None:
         def function_with_defaults(a: int = 1) -> int:
             return a


### PR DESCRIPTION
Fixes #658.

## Problem
`retry_if_exception_cause_type.__call__` walks the `__cause__` chain until it reaches `None`. A cyclic chain — the simplest being ordinary `raise e from e` — never reaches `None`, so the predicate spins forever at 100% CPU. Because the spin is inside the retry predicate, `stop_after_attempt` / `stop_after_delay` never get a chance to end the retry: stop conditions are only consulted after the predicate returns. Two-node cycles (`a.__cause__ = b; b.__cause__ = a`) hang the same way. The stdlib `traceback` module guards against exactly these cause/context cycles when walking exception chains.

## Fix
Track the ids of exceptions already visited and stop the walk when the chain repeats:

```python
seen: set[int] = set()
exc = retry_state.outcome.exception()
while exc is not None and id(exc) not in seen:
    if isinstance(exc.__cause__, self.exception_cause_types):
        return True
    seen.add(id(exc))
    exc = exc.__cause__
```

Behavior on acyclic chains is unchanged; a cyclic chain now finishes scanning each distinct exception once and returns the correct result.

## Tests
Adds `test_retry_if_exception_cause_type_with_cause_cycle` covering both cycle shapes (`raise e from e` and a two-node cycle). The new test hangs indefinitely on current `main` without the fix (only bounded by an external timeout) and passes in milliseconds with it. Full suite: 172 passed, 1 skipped, 12 subtests.

## Notes
As flagged in #658, the proposed `retry_unless_exception_cause_type` feature (#625 / #626) walks the cause chain the same way — if this fix lands, that feature can reuse the cycle-safe walk.

Prepared with AI assistance and independently verified before submission (fresh clone, hang reproduced on HEAD c650fb4, fix reviewed, full suite green, regression test confirmed non-vacuous).