### PR TITLE
fix: stop hanging on cyclic exception __cause__ chains

### DIFF
--- a/tenacity/retry.py
+++ b/tenacity/retry.py
@@ -161,7 +161,7 @@ class retry_if_exception_cause_type(retry_base):
     """Retries if any of the causes of the raised exception is of one or more types.
 
     The check on the type of the cause of the exception is done recursively (until finding
-    an exception in the chain that has no `__cause__`)
+    an exception in the chain that has no ``__cause__``, or a cycle is detected).
     """
 
     def __init__(
@@ -177,7 +177,12 @@ class retry_if_exception_cause_type(retry_base):
 
         if retry_state.outcome.failed:
             exc = retry_state.outcome.exception()
-            while exc is not None:
+            # Guard against cyclic __cause__ chains (e.g. ``raise e from e``),
+            # which would otherwise spin forever inside the predicate and
+            # prevent stop conditions from ever running (see #658).
+            seen: set[int] = set()
+            while exc is not None and id(exc) not in seen:
+                seen.add(id(exc))
                 if isinstance(exc.__cause__, self.exception_cause_types):
                     return True
                 exc = exc.__cause__

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -1441,6 +1441,31 @@ class TestDecoratorWrapper(unittest.TestCase):
         except NameError:
             pass
 
+    def test_retry_if_exception_cause_type_handles_cause_cycles(self) -> None:
+        """Cyclic __cause__ chains must not hang the retry predicate (#658)."""
+
+        def boom_self_cause() -> None:
+            try:
+                raise ValueError("inner")
+            except ValueError as e:
+                raise e from e
+
+        def boom_two_node_cycle() -> None:
+            a = ValueError("a")
+            b = RuntimeError("b")
+            a.__cause__ = b
+            b.__cause__ = a
+            raise a
+
+        for boom in (boom_self_cause, boom_two_node_cycle):
+            r = tenacity.Retrying(
+                retry=tenacity.retry_if_exception_cause_type(KeyError),
+                stop=tenacity.stop_after_attempt(2),
+                reraise=True,
+            )
+            with self.assertRaises((ValueError, RuntimeError)):
+                r(boom)
+
     def test_retry_preserves_argument_defaults(self) -> None:
         def function_with_defaults(a: int = 1) -> int:
             return a


### PR DESCRIPTION
## Summary
Fixes #658.

`retry_if_exception_cause_type` walked `__cause__` until `None`. A cyclic cause chain never ends, so the predicate spins at 100% CPU and **stop conditions never run** (they are only checked after the predicate returns).

This is legal Python:

```python
def boom():
    try:
        raise ValueError("inner")
    except ValueError as e:
        raise e from e  # self-referential __cause__

Retrying(
    retry=retry_if_exception_cause_type(KeyError),
    stop=stop_after_attempt(2),
    reraise=True,
)(boom)  # hung forever
```

Two-node cycles (`a.__cause__ = b; b.__cause__ = a`) hang the same way.

### Fix
Track `id(exc)` while walking and stop when a cycle is detected — the same idea as the stdlib `traceback` module’s cycle-safe chain walk.

### Tests
- Self-cause cycle (`raise e from e`)
- Two-node mutual cause cycle
- Existing cause-type tests still pass

## Checklist
- [x] Regression tests
- [x] Local `pytest -k exception_cause` green