### PR TITLE
fix: infer caller name in before_log when used as context manager (#511)

### DIFF
--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -508,6 +508,14 @@ class BaseRetrying(ABC):
         self.begin()
 
         retry_state = RetryCallState(self, fn=None, args=(), kwargs={})
+        # When used as a context manager without an explicit name=, infer the
+        # caller's qualified name from the frame that called next() on this
+        # generator (i.e. the for-loop body in user code).
+        if self._name is None:
+            _frame = sys._getframe(1)  # noqa: SLF001
+            retry_state._inferred_name = (  # noqa: SLF001
+                getattr(_frame.f_code, "co_qualname", None) or _frame.f_code.co_name
+            )
         while True:
             do = self.iter(retry_state=retry_state)
             if isinstance(do, DoAttempt):
@@ -618,6 +626,8 @@ class RetryCallState:
         self.next_action: RetryAction | None = None
         #: Next sleep time as decided by the retry manager.
         self.upcoming_sleep: float = 0.0
+        #: Inferred caller name for context-manager usage without explicit name=
+        self._inferred_name: str | None = None
 
     def get_fn_name(self) -> str:
         """Get the name of the function being retried.
@@ -628,6 +638,10 @@ class RetryCallState:
         """
         if self.fn is not None:
             return _utils.get_callback_name(self.fn)
+        # Inferred from the caller's frame in __iter__ (context-manager usage)
+        inferred: str | None = getattr(self, "_inferred_name", None)
+        if inferred is not None:
+            return inferred
         return str(self.retry_object)
 
     @property

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -177,7 +177,6 @@ class TestRetryingName(unittest.TestCase):
         args = log.call_args[0]
         assert "my_block" in args[1]
 
-
     def test_logging_infers_caller_name(self) -> None:
         """before_log infers the enclosing function name when no name= is given (#511).
 

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -178,6 +178,43 @@ class TestRetryingName(unittest.TestCase):
         assert "my_block" in args[1]
 
 
+    def test_logging_infers_caller_name(self) -> None:
+        """before_log infers the enclosing function name when no name= is given (#511).
+
+        When Retrying is used as a context manager without an explicit name=
+        parameter, retry_state.fn is None. Before the fix, get_fn_name() would
+        fall back to str(retry_object) == "<unknown>". Now __iter__ captures
+        sys._getframe(1) -- the for-loop frame -- and stores co_qualname / co_name
+        as retry_state._inferred_name so that before_log() can log something
+        meaningful instead of '<unknown>'.
+        """
+        import unittest.mock
+
+        log = unittest.mock.MagicMock()
+        logger = unittest.mock.MagicMock(log=log)
+
+        def my_retry_function() -> None:
+            with contextlib.suppress(Exception):
+                for attempt in Retrying(
+                    before=tenacity.before_log(logger, logging.INFO),
+                    stop=tenacity.stop_after_attempt(1),
+                ):
+                    with attempt:
+                        raise ValueError("boom")
+
+        my_retry_function()
+
+        # before_log must have been called at least once
+        assert log.call_args is not None, "before_log was never called"
+        msg = log.call_args[0][1]
+        assert "<unknown>" not in msg, (
+            f"Expected an inferred caller name in the log message, got: {msg!r}"
+        )
+        assert "my_retry_function" in msg, (
+            f"Expected 'my_retry_function' in the log message, got: {msg!r}"
+        )
+
+
 class TestStopConditions(unittest.TestCase):
     def test_never_stop(self) -> None:
         r = Retrying()


### PR DESCRIPTION
## Summary

Fixes #511 — `before_log()` logs `'<unknown>'` when `Retrying` is used as a context manager without an explicit `name=` parameter.

### Root cause

`__iter__` creates `RetryCallState(self, fn=None, ...)` because there is no wrapped function in the context-manager path. `get_fn_name()` then falls back to `str(self.retry_object)` which returns `"<unknown>"` when no `name=` was supplied.

### Fix

Two minimal changes in `tenacity/__init__.py`:

1. **`BaseRetrying.__iter__`** — after the first `next()` resumes the generator, `sys._getframe(1)` is the user's `for`-loop frame. We read `co_qualname` (Python ≥ 3.11) / `co_name` (older) and store it as `retry_state._inferred_name` when `self._name is None`.

2. **`RetryCallState.get_fn_name`** — checks `_inferred_name` before returning `str(self.retry_object)`, so the inferred name is used when available.

### Behaviour

```python
import logging
from tenacity import Retrying, RetryError, before_log

logger = logging.getLogger(__name__)

def my_function():
    for attempt in Retrying(before=before_log(logger, logging.DEBUG)):
        with attempt:
            raise Exception("hello")

# Before fix:  Starting call to '<unknown>', this is the 1st time calling it.
# After fix:   Starting call to 'my_function', this is the 1st time calling it.
```

Users who pass `name="something"` explicitly are completely unaffected.

### Changes

| File | Change |
|------|--------|
| `tenacity/__init__.py` | Capture caller frame in `__iter__`; check `_inferred_name` in `get_fn_name()` |
| `tests/test_tenacity.py` | Add `test_logging_infers_caller_name` regression test |
