### PR TITLE
Fix static typing of @retry decorated instance methods

### DIFF
--- a/releasenotes/notes/fix-decorated-method-binding-729ace6e58a9fefa.yaml
+++ b/releasenotes/notes/fix-decorated-method-binding-729ace6e58a9fefa.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fix static typing of ``@retry``-decorated instance methods. The
+    ``_RetryDecorated`` protocol did not implement ``__get__``, so type
+    checkers such as mypy and pyright/pylance treated ``instance.method`` the
+    same as the unbound ``Class.method``, requiring an explicit ``self``
+    argument and reporting an incorrect (``Unknown``/``Any``) return type for
+    ordinary calls like ``instance.method(value=1)``. This was purely a
+    static-analysis issue; the wrapper is a real function at runtime and
+    always bound correctly.

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -670,6 +670,22 @@ class _RetryDecorated(t.Protocol[P, R]):
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R: ...
 
+    # Without an explicit `__get__`, type checkers treat `_RetryDecorated` as a
+    # plain callable attribute rather than a descriptor, so accessing a
+    # decorated method through an instance keeps demanding the original
+    # unbound signature (including `self`). Declaring `__get__` here fixes
+    # attribute access on both the class and an instance; the runtime object
+    # is a real function (see `wraps` above), which already binds correctly,
+    # so this only affects static analysis. See issue #532.
+    @t.overload
+    def __get__(
+        self, instance: None, owner: type | None = None
+    ) -> "_RetryDecorated[P, R]": ...
+    @t.overload
+    def __get__(
+        self, instance: object, owner: type | None = None
+    ) -> "_RetryDecorated[..., R]": ...
+
 
 class _AsyncRetryDecorator(t.Protocol):
     @t.overload

--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -2196,6 +2196,28 @@ class TestRetryTyping(unittest.TestCase):
         self.assertEqual(with_raw_result, "1")
         self.assertEqual(with_constructor_result, "1")
 
+    def test_retry_decorated_method_keeps_bound_signature(self) -> None:
+        """A decorated instance method must type-check like a bound method.
+
+        Without a descriptor (``__get__``) on ``_RetryDecorated``, static type
+        checkers treat ``instance.method`` the same as the unbound
+        ``Class.method``, so a normal call with only the non-``self`` keyword
+        arguments looks like a type error and the return type resolves to
+        ``Any``/``Unknown``. This does not fail at runtime (functools.wraps
+        returns a real function, which Python always binds correctly), but it
+        does fail under `mypy --strict`, which also type-checks this file.
+        See issue #532.
+        """
+
+        class Doubler:
+            @retry(stop=tenacity.stop_after_attempt(3))
+            def double(self, value: int) -> int:
+                return value * 2
+
+        doubler = Doubler()
+        result: int = doubler.double(value=21)
+        self.assertEqual(result, 42)
+
 
 class TestMockingSleep:
     RETRY_ARGS = {


### PR DESCRIPTION
Fixes #532

## What changed and why

`_RetryDecorated`, the Protocol tenacity uses as the static return type of `@retry`-decorated callables, did not implement `__get__`. Without a descriptor, type checkers (mypy, pyright/pylance) treat `instance.method` the same as the unbound `Class.method`, so an ordinary call like `instance.method(value=1)` looks like it is missing `self`, and the return type resolves to `Unknown`/`Any` instead of the real return type. That matches the reporter's symptoms exactly: "No parameter named url" (keyword arguments no longer line up once `self` is expected positionally) and a return type that shows up as `Unknown | Awaitable[Unknown]`.

This reproduces with a plain synchronous method too, no third party decorator involved:

```python
class Foo:
    @retry(stop=stop_after_attempt(3))
    def double(self, value: int) -> int:
        return value * 2

f = Foo()
reveal_type(f.double)   # same type as Foo.double, self still required
```

This is purely a static analysis bug. At runtime the wrapper produced by `wraps()` is a real `functools.wraps`-decorated function, and real functions always bind `self` correctly, so nothing was broken for callers who are not running a type checker.

The fix adds `__get__` overloads to `_RetryDecorated`: accessed via the class it keeps returning the full unbound signature, accessed via an instance it returns `_RetryDecorated[..., R]`, i.e. self stripped, return type preserved. `Concatenate`-based self stripping is not expressible generically for an arbitrary already-captured `ParamSpec` with today's typing spec, so `...` is used for the bound parameter list, matching the pragmatic approach used elsewhere for generic method decorator stubs.

## Test plan

Added `tests/test_tenacity.py::TestRetryTyping::test_retry_decorated_method_keeps_bound_signature`, which decorates an instance method and calls it the normal bound way. Since this repo's `mypy --strict` gate also covers `tests/`, this test doubles as the regression check: I verified by temporarily reverting the `tenacity/__init__.py` change that mypy fails on this exact test with:

```
Missing positional argument "self" in call to "__call__" of "_RetryDecorated"  [call-arg]
```

With the fix restored:

```
$ mypy tenacity tests
Success: no issues found in 19 source files

$ pytest -q
174 passed, 1 warning, 12 subtests passed in 2.87s

$ ruff check .
All checks passed!

$ ruff format --check .
20 files already formatted
```

Also added a reno release note following the convention used for the comparable #519 typing fix.

## Note on the extra commit

The first CI run on this PR failed lint on 14 pre-existing `RUF036` violations across `tenacity/__init__.py`, `tenacity/asyncio/__init__.py`, and `tenacity/retry.py`, none of them on lines this PR touches. `ruff` is not version-pinned in `pyproject.toml`, and the last green run on `main` (same base commit as this branch) was on 2026-08-01, so a newer `ruff` release appears to have started enforcing `RUF036` ("None not at the end of a type union") in between. That means `main` would fail the same lint check if re-run today, independent of this PR.

Rather than leave the PR red over something unrelated, the second commit reorders `None` to the end of each flagged union (`ruff check --fix --unsafe-fixes .`, then `ruff format .`). Pure mechanical reordering, no behavior change - verified with a full `mypy` + `pytest` + `ruff` run after. Happy to drop that commit and rebase once `main` is fixed separately, if you'd rather keep it out of this PR.
